### PR TITLE
Fix README backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It allows easy sending/receiving of PDU binary data and conversion to/from JSON 
 
 ```bash
 pip install hakoniwa-pdu
-````
+```
 
 Check the installed version:
 
@@ -91,6 +91,4 @@ For detailed API usage, refer to the full API reference:
 ## 📜 License
 
 MIT License - see [LICENSE](./LICENSE) for details.
-
-```
 


### PR DESCRIPTION
## Summary
- fix Markdown fences in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68671341137083229ff02c59efe4b5ba