### PR TITLE
Remove Japanese import comment

### DIFF
--- a/src/hakoniwa_pdu/pdu_manager.py
+++ b/src/hakoniwa_pdu/pdu_manager.py
@@ -3,7 +3,7 @@ import os
 from hakoniwa_pdu.impl.communication_buffer import CommunicationBuffer
 from hakoniwa_pdu.impl.icommunication_service import ICommunicationService
 from hakoniwa_pdu.impl.data_packet import DataPacket
-from hakoniwa_pdu.impl.pdu_channel_config import PduChannelConfig  # ← 追加
+from hakoniwa_pdu.impl.pdu_channel_config import PduChannelConfig
 from hakoniwa_pdu.impl.pdu_convertor import PduConvertor
 import importlib.resources
 


### PR DESCRIPTION
## Summary
- tidy imports in `pdu_manager.py` by removing a Japanese comment

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867150aa85883229ee83cf3145ec5f9