### PR TITLE
Add tests and minor fix

### DIFF
--- a/src/hakoniwa_pdu/pdu_manager.py
+++ b/src/hakoniwa_pdu/pdu_manager.py
@@ -50,6 +50,7 @@ class PduManager:
         self.comm_buffer: Optional[CommunicationBuffer] = None
         self.comm_service: Optional[ICommunicationService] = None
         self.b_is_initialized = False
+        self.b_last_known_service_state = False
 
     def get_default_offset_path(self) -> str:
         # インストール済パッケージ内の offset ディレクトリパスを取得

--- a/tests/test_communication_buffer.py
+++ b/tests/test_communication_buffer.py
@@ -1,0 +1,45 @@
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from hakoniwa_pdu.impl.pdu_channel_config import PduChannelConfig
+from hakoniwa_pdu.impl.communication_buffer import CommunicationBuffer
+from hakoniwa_pdu.impl.data_packet import DataPacket
+
+SAMPLE_CONFIG = {
+    "robots": [
+        {
+            "name": "RobotA",
+            "shm_pdu_readers": [
+                {"org_name": "pos", "channel_id": 1, "pdu_size": 16, "type": "Pos"}
+            ],
+            "shm_pdu_writers": []
+        }
+    ]
+}
+
+
+def create_config_file():
+    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json")
+    json.dump(SAMPLE_CONFIG, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def test_put_and_get_packet():
+    path = create_config_file()
+    try:
+        cfg = PduChannelConfig(path)
+        buffer = CommunicationBuffer(cfg)
+        packet = DataPacket("RobotA", 1, bytearray(b"abc"))
+        buffer.put_packet(packet)
+        assert buffer.contains_buffer("RobotA", "pos")
+        data = buffer.get_buffer("RobotA", "pos")
+        assert data == bytearray(b"abc")
+        assert not buffer.contains_buffer("RobotA", "pos")
+    finally:
+        os.unlink(path)
+

--- a/tests/test_data_packet_errors.py
+++ b/tests/test_data_packet_errors.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from hakoniwa_pdu.impl.data_packet import DataPacket
+
+
+def test_decode_too_short():
+    # less than minimum 12 bytes
+    result = DataPacket.decode(bytearray(b'\x00\x01'))
+    assert result is None
+
+
+def test_decode_invalid_length():
+    # header indicates name_len longer than actual data
+    data = bytearray()
+    data.extend((8).to_bytes(4, 'little'))  # header len
+    data.extend((5).to_bytes(4, 'little'))  # name len
+    data.extend(b'ab')  # name bytes incomplete
+    data.extend((1).to_bytes(4, 'little'))  # channel_id
+    # no body data
+    result = DataPacket.decode(data)
+    assert result is None
+

--- a/tests/test_pdu_channel_config.py
+++ b/tests/test_pdu_channel_config.py
@@ -1,0 +1,51 @@
+import json
+import os
+import sys
+import tempfile
+
+# Add src directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from hakoniwa_pdu.impl.pdu_channel_config import PduChannelConfig
+
+SAMPLE_CONFIG = {
+    "robots": [
+        {
+            "name": "RobotA",
+            "shm_pdu_readers": [
+                {"org_name": "pos", "channel_id": 1, "pdu_size": 16, "type": "Pos"}
+            ],
+            "shm_pdu_writers": [
+                {"org_name": "cmd", "channel_id": 2, "pdu_size": 8, "type": "Cmd"}
+            ]
+        }
+    ]
+}
+
+
+def create_config_file():
+    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json")
+    json.dump(SAMPLE_CONFIG, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def test_pdu_channel_config_queries():
+    path = create_config_file()
+    try:
+        cfg = PduChannelConfig(path)
+        assert cfg.get_pdu_name("RobotA", 1) == "pos"
+        assert cfg.get_pdu_name("RobotA", 2) == "cmd"
+        assert cfg.get_pdu_name("RobotA", 999) is None
+
+        assert cfg.get_pdu_size("RobotA", "pos") == 16
+        assert cfg.get_pdu_size("RobotA", "unknown") == -1
+
+        assert cfg.get_pdu_type("RobotA", "cmd") == "Cmd"
+        assert cfg.get_pdu_type("RobotA", "missing") is None
+
+        assert cfg.get_pdu_channel_id("RobotA", "cmd") == 2
+        assert cfg.get_pdu_channel_id("RobotA", "missing") == -1
+    finally:
+        os.unlink(path)
+


### PR DESCRIPTION
## Summary
- expand unit test coverage for `DataPacket`
- add tests for `PduChannelConfig` and `CommunicationBuffer`
- initialize `b_last_known_service_state` in `PduManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671dc7f1fc8322a01896d2dede4bea