### PR TITLE
refactor: split PDU manager interfaces

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # hakoniwa-pdu-python
 
-This is a Python PDU communication library for the Hakoniwa simulator.  
+[![tests](https://github.com/hakoniwalab/hakoniwa-pdu-python/actions/workflows/tests.yml/badge.svg)](https://github.com/hakoniwalab/hakoniwa-pdu-python/actions/workflows/tests.yml)
+
+This is a Python PDU communication library for the Hakoniwa simulator.
 It allows easy sending/receiving of PDU binary data and conversion to/from JSON over WebSocket.
 
 ---

--- a/src/hakoniwa_pdu/impl/websocket_server_communication_service.py
+++ b/src/hakoniwa_pdu/impl/websocket_server_communication_service.py
@@ -52,8 +52,18 @@ class WebSocketServerCommunicationService(WebSocketBaseCommunicationService):
             self.websocket = None
         return True
 
-    async def _client_handler(self, websocket: WebSocketServerProtocol, path: str):
-        print(f"[DEBUG] _client_handler: new client connected")
+    async def _client_handler(
+        self, websocket: WebSocketServerProtocol, path: str | None = None
+    ):
+        """Handle a newly connected client.
+
+        Recent versions of the ``websockets`` package (>=11) invoke the
+        connection handler with only the websocket argument, while older
+        versions pass an additional ``path`` parameter.  To remain
+        compatible across versions we accept ``path`` as an optional
+        argument and ignore it.
+        """
+        print("[DEBUG] _client_handler: new client connected")
         if self.websocket is not None:
             # Allow only one client
             await websocket.close()

--- a/src/hakoniwa_pdu/rpc/ipdu_service_manager.py
+++ b/src/hakoniwa_pdu/rpc/ipdu_service_manager.py
@@ -1,338 +1,234 @@
 from abc import ABC, abstractmethod
-from hakoniwa_pdu.pdu_manager import PduManager
 from typing import Any, Tuple, Optional, Callable, Type
 
-# 型エイリアスを定義
+from hakoniwa_pdu.pdu_manager import PduManager
+
+# 型エイリアス
 ClientId = Any
 PduData = bytearray
 PyPduData = Any  # Python側でのPDUデータ形式
 
 Event = Any  # poll結果として返される、実装依存のイベントオブジェクト
 
-class IPduServiceManager(PduManager, ABC):
-    """
-    RPCサービスのプロトコル層(client_protocol, server_protocol)が利用するための、
-    通信方式(SHM, Remote)に依存しない低レベル操作を定義するインターフェース。
-    """
-    def register_req_serializer(self, cls_req_packet: Type[Any], req_encoder: Callable, req_decoder: Callable) -> None:
-        """
-        クライアントのリクエストPDUをエンコード/デコードする関数を登録する。
 
-        Args:
-            req_encoder: リクエストPDUをエンコードする関数 (dict -> bytes)。
-            req_decoder: リクエストPDUをデコードする関数 (bytes -> dict)。
-        """
+class IPduServiceManager(PduManager, ABC):
+    """RPCサービス用PDU操作の共通インターフェース"""
+
+    def register_req_serializer(
+        self,
+        cls_req_packet: Type[Any],
+        req_encoder: Callable,
+        req_decoder: Callable,
+    ) -> None:
         self.cls_req_packet = cls_req_packet
         self.req_encoder = req_encoder
         self.req_decoder = req_decoder
 
-    def register_res_serializer(self, cls_res_packet: Type[Any], res_encoder: Callable, res_decoder: Callable) -> None:
-        """
-        クライアントのレスポンスPDUをエンコード/デコードする関数を登録する。
-
-        Args:
-            res_encoder: レスポンスPDUをエンコードする関数 (dict -> bytes)。
-            res_decoder: レスポンスPDUをデコードする関数 (bytes -> dict)。
-        """
+    def register_res_serializer(
+        self,
+        cls_res_packet: Type[Any],
+        res_encoder: Callable,
+        res_decoder: Callable,
+    ) -> None:
         self.cls_res_packet = cls_res_packet
         self.res_encoder = res_encoder
         self.res_decoder = res_decoder
 
-    # --- サーバー側操作 ---
+    # --- サーバー側共通操作 ---
     @abstractmethod
     def initialize_services(self, service_config_path: str, delta_time_usec: int) -> int:
-        pass
-
-    @abstractmethod
-    def start_rpc_service_nowait(self, service_name: str, max_clients: int) -> bool:
-        pass
-
-    @abstractmethod
-    async def start_rpc_service(self, service_name: str, max_clients: int) -> bool:
-        """
-        サーバーとしてサービスを開始する。
-
-        Args:
-            service_name: 公開するサービス名。
-            max_clients: 最大クライアント数。
-
-        Returns:
-            成功した場合はTrue。
-        """
         pass
 
     @abstractmethod
     def sleep(self, time_sec: float) -> bool:
         pass
 
-    # constants
-
     # ====== [ Common API Status / Result Codes ] ======
-    API_STATUS_NONE       = 0
-    API_STATUS_DOING      = 1
-    API_STATUS_CANCELING  = 2
-    API_STATUS_DONE       = 3
-    API_STATUS_ERROR      = 4
+    API_STATUS_NONE = 0
+    API_STATUS_DOING = 1
+    API_STATUS_CANCELING = 2
+    API_STATUS_DONE = 3
+    API_STATUS_ERROR = 4
 
-    API_RESULT_CODE_OK       = 0
-    API_RESULT_CODE_ERROR    = 1
+    API_RESULT_CODE_OK = 0
+    API_RESULT_CODE_ERROR = 1
     API_RESULT_CODE_CANCELED = 2
-    API_RESULT_CODE_INVALID  = 3
-    API_RESULT_CODE_BUSY     = 4
+    API_RESULT_CODE_INVALID = 3
+    API_RESULT_CODE_BUSY = 4
 
     # ====== [ Client Opcode ] ======
     CLIENT_API_OPCODE_REQUEST = 0
-    CLIENT_API_OPCODE_CANCEL  = 1
+    CLIENT_API_OPCODE_CANCEL = 1
 
     # ====== [ Client Events ] ======
-    CLIENT_API_EVENT_NONE              = 0
-    CLIENT_API_EVENT_RESPONSE_IN       = 1
-    CLIENT_API_EVENT_REQUEST_TIMEOUT   = 2
+    CLIENT_API_EVENT_NONE = 0
+    CLIENT_API_EVENT_RESPONSE_IN = 1
+    CLIENT_API_EVENT_REQUEST_TIMEOUT = 2
     CLIENT_API_EVENT_REQUEST_CANCEL_DONE = 3
 
     # ====== [ Client State ] ======
-    CLIENT_API_STATE_IDLE      = 0
-    CLIENT_API_STATE_DOING     = 1
+    CLIENT_API_STATE_IDLE = 0
+    CLIENT_API_STATE_DOING = 1
     CLIENT_API_STATE_CANCELING = 2
 
     # ====== [ Server Events ] ======
-    SERVER_API_EVENT_NONE         = 0
-    SERVER_API_EVENT_REQUEST_IN   = 1
+    SERVER_API_EVENT_NONE = 0
+    SERVER_API_EVENT_REQUEST_IN = 1
     SERVER_API_EVENT_REQUEST_CANCEL = 2
 
     # ====== [ Server Status ] ======
-    SERVER_API_STATUS_IDLE      = 0
-    SERVER_API_STATUS_DOING     = 1
+    SERVER_API_STATUS_IDLE = 0
+    SERVER_API_STATUS_DOING = 1
     SERVER_API_STATUS_CANCELING = 2
 
     # ====== [ Trigger Events ] ======
     TRIGGER_EVENT_ID_START = 0
-    TRIGGER_EVENT_ID_STOP  = 1
+    TRIGGER_EVENT_ID_STOP = 1
     TRIGGER_EVENT_ID_RESET = 2
 
     @abstractmethod
-    def get_response_buffer(self, client_id: ClientId, status: int, result_code: int) -> Optional[PduData]:
-        """
-        指定されたクライアントのレスポンスバッファを取得する。
-
-        Args:
-            client_id: クライアントID。
-            status: ステータスコード。
-            result_code: 結果コード。
-
-        Returns:
-            レスポンスPDUデータ。取得できなかった場合はNone。
-        """
-        pass
-
-    @abstractmethod
-    async def poll_request(self) -> Event:
-        """
-        サーバー側でクライアントからのイベント（リクエスト受信、キャンセル要求など）をポーリングする。
-
-        Returns:
-            発生したイベントを示すオブジェクト。
-        """
-        pass
-
-    @abstractmethod
-    def poll_request_nowait(self) -> Event:
-        """
-        サーバー側でクライアントからのイベントをポーリングする（nowait版）。
-        """
+    def get_response_buffer(
+        self, client_id: ClientId, status: int, result_code: int
+    ) -> Optional[PduData]:
         pass
 
     @abstractmethod
     def get_request(self) -> Tuple[ClientId, PduData]:
-        """
-        受信したリクエストデータを取得する。
-        poll_request()でリクエスト受信イベントを確認した後に呼び出す。
-
-        Returns:
-            (クライアントID, リクエストPDUデータ) のタプル。
-        """
         pass
 
     @abstractmethod
-    async def put_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
-        """
-        指定されたクライアントに正常応答PDUを送信する。
-
-        Args:
-            client_id: 送信先クライアントのID。
-            pdu_data: 送信するレスポンスPDUデータ。
-        """
-        pass
-
-    @abstractmethod
-    def put_response_nowait(self, client_id: ClientId, pdu_data: PduData) -> bool:
-        """
-        指定されたクライアントに正常応答PDUを送信する（nowait版）。
-
-        Args:
-            client_id: 送信先クライアントのID。
-            pdu_data: 送信するレスポンスPDUデータ。
-        """
-        pass
-
-    @abstractmethod
-    async def put_cancel_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
-        """
-        指定されたクライアントにキャンセル応答PDUを送信する。
-
-        Args:
-            client_id: 送信先クライアントのID。
-            pdu_data: 送信するレスポンスPDUデータ。
-        """
-        pass
-
-    @abstractmethod
-    def put_cancel_response_nowait(self, client_id: ClientId, pdu_data: PduData) -> bool:
-        """
-        指定されたクライアントにキャンセル応答PDUを送信する（nowait版）。
-
-        Args:
-            client_id: 送信先クライアントのID。
-            pdu_data: 送信するレスポンスPDUデータ。
-        """
-        pass
-
-    # --- サーバーイベント種別判定 ---
-
-    @abstractmethod
-    def is_server_event_request_in(self, event: Event) -> bool:
-        """サーバー：リクエスト受信イベントか"""
-        pass
-
-    @abstractmethod
-    def is_server_event_cancel(self, event: Event) -> bool:
-        """サーバー：キャンセル要求イベントか"""
-        pass
-
-    @abstractmethod
-    def is_server_event_none(self, event: Event) -> bool:
-        """サーバー：イベントが発生しなかったか"""
-        pass
-
-    # --- クライアント側操作 ---
-
-    @abstractmethod
-    async def register_client(self, service_name: str, client_name: str) -> Optional[ClientId]:
-        pass
-    
-    @abstractmethod
-    def register_client_nowait(self, service_name: str, client_name: str) -> Optional[ClientId]:
-        """
-        クライアントとしてサービスに登録する。
-
-        Args:
-            service_name: 接続先のサービス名。
-            client_name: 自身のクライアント名。
-
-        Returns:
-            成功した場合はクライアントID、失敗した場合はNone。
-        """
-        pass
-
-    @abstractmethod
-    async def call_request(self, client_id: ClientId, pdu_data: PduData, timeout_msec: int) -> bool:
-        """
-        サービスにリクエストPDUを送信する。
-
-        Args:
-            client_id: 登録時に取得したクライアントID。
-            pdu_data: 送信するリクエストPDUデータ。
-            timeout_msec: タイムアウト（ミリ秒）。
-        """
-        pass
-
-    @abstractmethod
-    def call_request_nowait(self, client_id: ClientId, pdu_data: PduData, timeout_msec: int) -> bool:
-        """
-        サービスにリクエストPDUを送信する（非同期）。
-
-        Args:
-            client_id: 登録時に取得したクライアントID。
-            pdu_data: 送信するリクエストPDUデータ。
-            timeout_msec: タイムアウト（ミリ秒）。
-
-        Returns:
-            成功した場合はTrue、失敗した場合はFalse。
-        """
-        pass
-
-    @abstractmethod
-    def get_request_buffer(self, client_id: int, opcode: int, poll_interval_msec: int, request_id: int) -> bytes:
-        """
-        クライアント側でリクエストPDUを構築するためのバッファ（雛形）を取得する。
-        pdu_managerの実装に依存して、必要なpduサイズ、オフセットを考慮した
-        バイナリが返却される。呼び出し元は、そのバイナリをデコードして、
-        必要なデータを設定し、再度エンコードして、call_request()を呼び出す。
-        """
+    def get_request_buffer(
+        self, client_id: int, opcode: int, poll_interval_msec: int, request_id: int
+    ) -> bytes:
         pass
 
     @abstractmethod
     def poll_response(self, client_id: ClientId) -> Event:
-        """
-        クライアント側でサーバーからのイベント（レスポンス受信、タイムアウトなど）をポーリングする。
-
-        Args:
-            client_id: 登録時に取得したクライアントID。
-
-        Returns:
-            発生したイベントを示すオブジェクト。
-        """
         pass
 
     @abstractmethod
-    def get_response(self, client_id: ClientId) -> PduData:
-        """
-        受信したレスポンスPDUデータを取得する。
-        poll_response()でレスポンス受信イベントを確認した後に呼び出す。
+    def get_response(self, service_name: str, client_id: ClientId) -> PduData:
+        pass
 
-        Args:
-            client_id: 登録時に取得したクライアントID。
-        """
+    # --- サーバーイベント種別判定 ---
+    @abstractmethod
+    def is_server_event_request_in(self, event: Event) -> bool:
         pass
 
     @abstractmethod
-    async def cancel_request(self, client_id: ClientId) -> bool:
-        """
-        送信済みのリクエストのキャンセルを要求する。
-
-        Args:
-            client_id: 登録時に取得したクライアントID。
-        """
+    def is_server_event_cancel(self, event: Event) -> bool:
         pass
 
     @abstractmethod
-    def cancel_request_nowait(self, client_id: ClientId) -> bool:
+    def is_server_event_none(self, event: Event) -> bool:
         pass
 
-    # --- クライアントイベント種別判定 ---
-
+    # --- クライアント側イベント判定 ---
     @abstractmethod
     def is_client_event_response_in(self, event: Event) -> bool:
-        """クライアント：レスポンス受信イベントか"""
         pass
 
     @abstractmethod
     def is_client_event_timeout(self, event: Event) -> bool:
-        """クライアント：タイムアウトイベントか"""
         pass
 
     @abstractmethod
     def is_client_event_cancel_done(self, event: Event) -> bool:
-        """クライアント：キャンセル完了イベントか"""
         pass
 
     @abstractmethod
     def is_client_event_none(self, event: Event) -> bool:
-        """クライアント：イベントが発生しなかったか"""
         pass
 
     @property
     @abstractmethod
     def requires_external_request_id(self) -> bool:
-        """request_idを外部から設定する必要があるかを示すフラグ"""
         pass
+
+
+class IPduServiceManagerImmediate(IPduServiceManager):
+    """nowait系APIを提供する実装が従うインターフェース"""
+
+    # --- サーバー側操作 ---
+    @abstractmethod
+    def start_rpc_service(self, service_name: str, max_clients: int) -> bool:
+        pass
+
+    @abstractmethod
+    def poll_request(self) -> Event:
+        pass
+
+    @abstractmethod
+    def put_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
+        pass
+
+    @abstractmethod
+    def put_cancel_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
+        pass
+
+    # --- クライアント側操作 ---
+    @abstractmethod
+    def register_client(self, service_name: str, client_name: str) -> Optional[ClientId]:
+        pass
+
+    @abstractmethod
+    def call_request(
+        self, client_id: ClientId, pdu_data: PduData, timeout_msec: int
+    ) -> bool:
+        pass
+
+    @abstractmethod
+    def cancel_request(self, client_id: ClientId) -> bool:
+        pass
+
+
+class IPduServiceManagerBlocking(IPduServiceManager):
+    """async/awaitを用いるブロッキングAPIのインターフェース"""
+
+    # --- サーバー側操作 ---
+    @abstractmethod
+    async def start_rpc_service(self, service_name: str, max_clients: int) -> bool:
+        pass
+
+    @abstractmethod
+    async def poll_request(self) -> Event:
+        pass
+
+    @abstractmethod
+    async def put_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
+        pass
+
+    @abstractmethod
+    async def put_cancel_response(
+        self, client_id: ClientId, pdu_data: PduData
+    ) -> bool:
+        pass
+
+    # --- クライアント側操作 ---
+    @abstractmethod
+    async def register_client(
+        self, service_name: str, client_name: str
+    ) -> Optional[ClientId]:
+        pass
+
+    @abstractmethod
+    async def call_request(
+        self, client_id: ClientId, pdu_data: PduData, timeout_msec: int
+    ) -> bool:
+        pass
+
+    @abstractmethod
+    async def cancel_request(self, client_id: ClientId) -> bool:
+        pass
+
+
+__all__ = [
+    "ClientId",
+    "PduData",
+    "PyPduData",
+    "Event",
+    "IPduServiceManager",
+    "IPduServiceManagerImmediate",
+    "IPduServiceManagerBlocking",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import asyncio
+import inspect
+import pytest
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: mark test to run with asyncio")
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    if inspect.iscoroutinefunction(pyfuncitem.obj):
+        marker = pyfuncitem.get_closest_marker("asyncio")
+        if marker is not None:
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+            return True

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import pytest
 from hakoniwa_pdu.impl.websocket_communication_service import WebSocketCommunicationService
 from hakoniwa_pdu.impl.websocket_server_communication_service import WebSocketServerCommunicationService
@@ -12,13 +13,19 @@ from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket imp
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket import pdu_to_py_AddTwoIntsRequestPacket, py_to_pdu_AddTwoIntsRequestPacket
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import pdu_to_py_AddTwoIntsResponsePacket, py_to_pdu_AddTwoIntsResponsePacket
 
+OFFSET_PATH = "/usr/local/hakoniwa/share/hakoniwa/offset"
+
+
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.path.exists(OFFSET_PATH), reason="offset files not present"
+)
 async def test_remote_rpc_call():
     # 1. Setup
     uri = "ws://localhost:8772"
     pdu_config_path = "tests/pdu_config.json"
     service_config_path = "examples/service.json"
-    offset_path = "/usr/local/hakoniwa/share/hakoniwa/offset"
+    offset_path = OFFSET_PATH
 
     # Server setup
     server_comm = WebSocketServerCommunicationService(version="v2")


### PR DESCRIPTION
## Summary
- split IPduServiceManager into immediate and blocking variants
- update SHM and remote PDU service managers to new interfaces
- adjust protocol client/server to use unified method names
- add minimal pytest-asyncio plugin and skip RPC test when offset data missing
- fix WebSocket server handler to accept optional path for websockets>=11
- add GitHub Actions workflow to run tests on pushes and pull requests
- show test results in README via CI status badge

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ad521b4c83229c28e199eb6d6758