### PR TITLE
Add auto-wiring helpers for RPC protocol

### DIFF
--- a/examples/new_asset_client.py
+++ b/examples/new_asset_client.py
@@ -4,16 +4,13 @@ import asyncio
 import sys
 import hakopy
 
-# 新しいRPCコンポーネントをインポート
-from hakoniwa_pdu.rpc.shm.shm_pdu_service_client_manager import ShmPduServiceClientManager
-from hakoniwa_pdu.rpc.protocol_client import ProtocolClient
-
-# PDUの型定義とエンコーダ/デコーダをインポート
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import AddTwoIntsRequest
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequestPacket import AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket import AddTwoIntsResponsePacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket  import pdu_to_py_AddTwoIntsRequestPacket, py_to_pdu_AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import pdu_to_py_AddTwoIntsResponsePacket, py_to_pdu_AddTwoIntsResponsePacket
+from hakoniwa_pdu.rpc.shm.shm_pdu_service_client_manager import (
+    ShmPduServiceClientManager,
+)
+from hakoniwa_pdu.rpc.auto_wire import make_protocol_client
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
+    AddTwoIntsRequest,
+)
 
 # --- クライアント設定 ---
 ASSET_NAME = 'NewClient'
@@ -26,7 +23,7 @@ DELTA_TIME_USEC = 1000 * 1000
 
 # グローバル変数としてマネージャとプロトコルを保持
 pdu_manager: ShmPduServiceClientManager = None
-protocol_client: ProtocolClient = None
+protocol_client = None
 
 async def run_rpc_client():
     """
@@ -74,16 +71,11 @@ def my_on_initialize(context):
     global pdu_manager, protocol_client
     print("Initializing PDU Service Manager for SHM...")
 
-    protocol_client = ProtocolClient(
+    protocol_client = make_protocol_client(
         pdu_manager=pdu_manager,
         service_name=SERVICE_NAME,
         client_name=CLIENT_NAME,
-        cls_req_packet=AddTwoIntsRequestPacket,  # リクエストパケットのクラス
-        cls_res_packet=AddTwoIntsResponsePacket,  # レスポンスパケットのクラス
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket, # リクエストのエンコーダ
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,  # リクエストのデコーダ
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket, # レスポンスのエンコーダ
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket   # レスポンスのデコーダ
+        srv="AddTwoInts",
     )
     # クライアントをサービスに登録
     print(f"Registering client '{CLIENT_NAME}' to service '{SERVICE_NAME}'...")

--- a/examples/new_asset_server.py
+++ b/examples/new_asset_server.py
@@ -3,19 +3,17 @@
 import asyncio
 import sys
 import hakopy
-from typing import Any
 
-# 新しいRPCコンポーネントをインポート
-from hakoniwa_pdu.rpc.shm.shm_pdu_service_server_manager import ShmPduServiceServerManager
-from hakoniwa_pdu.rpc.protocol_server import ProtocolServer
-
-# PDUの型定義とエンコーダ/デコーダをインポート
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import AddTwoIntsRequest
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import AddTwoIntsResponse
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequestPacket import AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket import AddTwoIntsResponsePacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket import py_to_pdu_AddTwoIntsRequestPacket, pdu_to_py_AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import py_to_pdu_AddTwoIntsResponsePacket, pdu_to_py_AddTwoIntsResponsePacket
+from hakoniwa_pdu.rpc.shm.shm_pdu_service_server_manager import (
+    ShmPduServiceServerManager,
+)
+from hakoniwa_pdu.rpc.auto_wire import make_protocol_server
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
+    AddTwoIntsRequest,
+)
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import (
+    AddTwoIntsResponse,
+)
 
 # --- サーバー設定 ---
 ASSET_NAME = 'NewServer'
@@ -27,7 +25,7 @@ DELTA_TIME_USEC = 1000 * 1000
 
 # グローバル変数としてマネージャとプロトコルを保持
 pdu_manager: ShmPduServiceServerManager = None
-protocol_server: ProtocolServer = None
+protocol_server = None
 
 async def add_two_ints_handler(request: AddTwoIntsRequest) -> AddTwoIntsResponse:
     """
@@ -47,16 +45,11 @@ def my_on_initialize(context):
     global pdu_manager, protocol_server
     print(f"Starting service: {SERVICE_NAME}")
     # サーバープロトコルを初期化
-    protocol_server = ProtocolServer(
-        service_name=SERVICE_NAME,
-        max_clients=1,
+    protocol_server = make_protocol_server(
         pdu_manager=pdu_manager,
-        cls_req_packet=AddTwoIntsRequestPacket,  # リクエストPDUの型
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket,  # リクエストのエンコーダ
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,  # リクエストのデコーダ
-        cls_res_packet=AddTwoIntsResponsePacket,  # レスポンスPDUの型
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket,  # レスポンスのエンコーダ
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket  # レスポンスのデコーダ
+        service_name=SERVICE_NAME,
+        srv="AddTwoInts",
+        max_clients=1,
     )
     # サービスを開始
     if not protocol_server.start_service_nowait():

--- a/examples/remote_rpc_client.py
+++ b/examples/remote_rpc_client.py
@@ -9,18 +9,9 @@ from hakoniwa_pdu.impl.websocket_communication_service import WebSocketCommunica
 from hakoniwa_pdu.rpc.remote.remote_pdu_service_client_manager import (
     RemotePduServiceClientManager,
 )
-from hakoniwa_pdu.rpc.protocol_client import ProtocolClient
-
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import AddTwoIntsRequest
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequestPacket import AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket import AddTwoIntsResponsePacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket import (
-    pdu_to_py_AddTwoIntsRequestPacket,
-    py_to_pdu_AddTwoIntsRequestPacket,
-)
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import (
-    pdu_to_py_AddTwoIntsResponsePacket,
-    py_to_pdu_AddTwoIntsResponsePacket,
+from hakoniwa_pdu.rpc.auto_wire import make_protocol_client
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
+    AddTwoIntsRequest,
 )
 
 ASSET_NAME = "RemoteClient"
@@ -47,17 +38,16 @@ async def main() -> None:
     )
     manager.initialize_services(args.service_config, DELTA_TIME_USEC)
 
-    client = ProtocolClient(
+    client = make_protocol_client(
         pdu_manager=manager,
         service_name=SERVICE_NAME,
         client_name=CLIENT_NAME,
-        cls_req_packet=AddTwoIntsRequestPacket,
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket,
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,
-        cls_res_packet=AddTwoIntsResponsePacket,
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket,
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket,
+        srv="AddTwoInts",
     )
+
+    if not await client.start_service(args.uri):
+        print("通信サービス開始に失敗しました")
+        return
 
     if not await client.register():
         print("クライアント登録に失敗しました")

--- a/examples/remote_rpc_server.py
+++ b/examples/remote_rpc_server.py
@@ -11,19 +11,12 @@ from hakoniwa_pdu.impl.websocket_server_communication_service import (
 from hakoniwa_pdu.rpc.remote.remote_pdu_service_server_manager import (
     RemotePduServiceServerManager,
 )
-from hakoniwa_pdu.rpc.protocol_server import ProtocolServer
-
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import AddTwoIntsRequest
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequestPacket import AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import AddTwoIntsResponse
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket import AddTwoIntsResponsePacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket import (
-    py_to_pdu_AddTwoIntsRequestPacket,
-    pdu_to_py_AddTwoIntsRequestPacket,
+from hakoniwa_pdu.rpc.auto_wire import make_protocol_server
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
+    AddTwoIntsRequest,
 )
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import (
-    py_to_pdu_AddTwoIntsResponsePacket,
-    pdu_to_py_AddTwoIntsResponsePacket,
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import (
+    AddTwoIntsResponse,
 )
 
 ASSET_NAME = "RemoteServer"
@@ -57,16 +50,11 @@ async def main() -> None:
     )
     manager.initialize_services(args.service_config, DELTA_TIME_USEC)
 
-    server = ProtocolServer(
-        service_name=SERVICE_NAME,
-        max_clients=1,
+    server = make_protocol_server(
         pdu_manager=manager,
-        cls_req_packet=AddTwoIntsRequestPacket,
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket,
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,
-        cls_res_packet=AddTwoIntsResponsePacket,
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket,
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket,
+        service_name=SERVICE_NAME,
+        srv="AddTwoInts",
+        max_clients=1,
     )
 
     if not await server.start_service():

--- a/src/hakoniwa_pdu/rpc/auto_wire.py
+++ b/src/hakoniwa_pdu/rpc/auto_wire.py
@@ -1,0 +1,103 @@
+"""Utility helpers to construct ProtocolClient/Server with minimal imports."""
+from importlib import import_module
+from typing import Any, Tuple, Type, Callable, Optional
+
+
+def _load_protocol_components(srv: str, pkg: str) -> Tuple[type, type, Callable, Callable, Callable, Callable]:
+    """Dynamically load packet classes and converters for a service.
+
+    Parameters
+    ----------
+    srv: str
+        Service name such as ``"AddTwoInts"``.
+    pkg: str
+        Base package where PDU modules reside.
+
+    Returns
+    -------
+    tuple
+        ``(ReqPacket, ResPacket, req_encoder, req_decoder, res_encoder, res_decoder)``
+    """
+    req_packet_mod = f"{pkg}.pdu_pytype_{srv}RequestPacket"
+    res_packet_mod = f"{pkg}.pdu_pytype_{srv}ResponsePacket"
+    req_conv_mod = f"{pkg}.pdu_conv_{srv}RequestPacket"
+    res_conv_mod = f"{pkg}.pdu_conv_{srv}ResponsePacket"
+
+    try:
+        ReqPacket = getattr(import_module(req_packet_mod), f"{srv}RequestPacket")
+        ResPacket = getattr(import_module(res_packet_mod), f"{srv}ResponsePacket")
+        req_conv = import_module(req_conv_mod)
+        res_conv = import_module(res_conv_mod)
+    except (ImportError, AttributeError) as e:
+        raise RuntimeError(f"Failed to load protocol components for service '{srv}'") from e
+
+    try:
+        req_encoder = getattr(req_conv, f"py_to_pdu_{srv}RequestPacket")
+        req_decoder = getattr(req_conv, f"pdu_to_py_{srv}RequestPacket")
+        res_encoder = getattr(res_conv, f"py_to_pdu_{srv}ResponsePacket")
+        res_decoder = getattr(res_conv, f"pdu_to_py_{srv}ResponsePacket")
+    except AttributeError as e:
+        raise RuntimeError(f"Missing converter functions for service '{srv}'") from e
+
+    return ReqPacket, ResPacket, req_encoder, req_decoder, res_encoder, res_decoder
+
+
+def make_protocol_client(*, pdu_manager: Any, service_name: str, client_name: str,
+                         srv: str,
+                         pkg: str = "hakoniwa_pdu.pdu_msgs.hako_srv_msgs",
+                         ProtocolClientClass: Optional[Type[Any]] = None):
+    """Create :class:`ProtocolClient` from a service name.
+
+    Parameters
+    ----------
+    pdu_manager: Any
+        Manager instance controlling PDU communication.
+    service_name: str
+        Name of the remote service (e.g. ``"Service/Add"``).
+    client_name: str
+        Name of this client instance.
+    srv: str
+        Simple service type name such as ``"AddTwoInts"``.
+    pkg: str, optional
+        Package prefix where generated PDU modules exist.
+    ProtocolClientClass: Type, optional
+        Custom ``ProtocolClient`` class to instantiate.
+    """
+    if ProtocolClientClass is None:
+        from .protocol_client import ProtocolClient as ProtocolClientClass  # type: ignore
+
+    ReqPacket, ResPacket, req_encoder, req_decoder, res_encoder, res_decoder = _load_protocol_components(srv, pkg)
+
+    return ProtocolClientClass(
+        pdu_manager=pdu_manager,
+        service_name=service_name,
+        client_name=client_name,
+        cls_req_packet=ReqPacket,
+        req_encoder=req_encoder,
+        req_decoder=req_decoder,
+        cls_res_packet=ResPacket,
+        res_encoder=res_encoder,
+        res_decoder=res_decoder,
+    )
+
+
+def make_protocol_server(*, pdu_manager: Any, service_name: str, srv: str, max_clients: int,
+                         pkg: str = "hakoniwa_pdu.pdu_msgs.hako_srv_msgs",
+                         ProtocolServerClass: Optional[Type[Any]] = None):
+    """Create :class:`ProtocolServer` from a service name."""
+    if ProtocolServerClass is None:
+        from .protocol_server import ProtocolServer as ProtocolServerClass  # type: ignore
+
+    ReqPacket, ResPacket, req_encoder, req_decoder, res_encoder, res_decoder = _load_protocol_components(srv, pkg)
+
+    return ProtocolServerClass(
+        pdu_manager=pdu_manager,
+        service_name=service_name,
+        max_clients=max_clients,
+        cls_req_packet=ReqPacket,
+        req_encoder=req_encoder,
+        req_decoder=req_decoder,
+        cls_res_packet=ResPacket,
+        res_encoder=res_encoder,
+        res_decoder=res_decoder,
+    )

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -11,14 +11,16 @@ from hakoniwa_pdu.rpc.remote.remote_pdu_service_server_manager import (
 from hakoniwa_pdu.rpc.remote.remote_pdu_service_client_manager import (
     RemotePduServiceClientManager,
 )
-from hakoniwa_pdu.rpc.protocol_client import ProtocolClient
-from hakoniwa_pdu.rpc.protocol_server import ProtocolServer
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import AddTwoIntsRequest
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import AddTwoIntsResponse
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequestPacket import AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponsePacket import AddTwoIntsResponsePacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsRequestPacket import pdu_to_py_AddTwoIntsRequestPacket, py_to_pdu_AddTwoIntsRequestPacket
-from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_conv_AddTwoIntsResponsePacket import pdu_to_py_AddTwoIntsResponsePacket, py_to_pdu_AddTwoIntsResponsePacket
+from hakoniwa_pdu.rpc.auto_wire import (
+    make_protocol_client,
+    make_protocol_server,
+)
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
+    AddTwoIntsRequest,
+)
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import (
+    AddTwoIntsResponse,
+)
 
 OFFSET_PATH = "./tests/config/offset"
 
@@ -37,16 +39,11 @@ async def test_remote_rpc_call():
         "test_server", pdu_config_path, offset_path, server_comm, uri
     )
     server_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
-    protocol_server = ProtocolServer(
-        service_name="Service/Add",
-        max_clients=1,
+    protocol_server = make_protocol_server(
         pdu_manager=server_pdu_manager,
-        cls_req_packet=AddTwoIntsRequestPacket,
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket,
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,
-        cls_res_packet=AddTwoIntsResponsePacket,
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket,
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket
+        service_name="Service/Add",
+        srv="AddTwoInts",
+        max_clients=1,
     )
 
     async def add_two_ints_handler(request: AddTwoIntsRequest) -> AddTwoIntsResponse:
@@ -63,16 +60,11 @@ async def test_remote_rpc_call():
         "test_client", pdu_config_path, offset_path, client_comm, uri
     )
     client_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
-    protocol_client = ProtocolClient(
+    protocol_client = make_protocol_client(
         pdu_manager=client_pdu_manager,
         service_name="Service/Add",
         client_name="test_client",
-        cls_req_packet=AddTwoIntsRequestPacket,
-        req_encoder=py_to_pdu_AddTwoIntsRequestPacket,
-        req_decoder=pdu_to_py_AddTwoIntsRequestPacket,
-        cls_res_packet=AddTwoIntsResponsePacket,
-        res_encoder=py_to_pdu_AddTwoIntsResponsePacket,
-        res_decoder=pdu_to_py_AddTwoIntsResponsePacket
+        srv="AddTwoInts",
     )
 
     # 2. Register client


### PR DESCRIPTION
## Summary
- add make_protocol_client/make_protocol_server helpers for RPC auto wiring
- simplify RPC test by using auto-wiring helpers
- apply auto-wiring API to new_asset and remote RPC examples
- start remote RPC client service before registration

## Testing
- `python -m py_compile examples/new_asset_client.py examples/new_asset_server.py examples/remote_rpc_client.py examples/remote_rpc_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f638b6c8322b9c70ad8070c0c43