### PR TITLE
Refactor protocol client/server into blocking and immediate variants

### DIFF
--- a/examples/new_asset_client.py
+++ b/examples/new_asset_client.py
@@ -8,6 +8,7 @@ from hakoniwa_pdu.rpc.shm.shm_pdu_service_client_manager import (
     ShmPduServiceClientManager,
 )
 from hakoniwa_pdu.rpc.auto_wire import make_protocol_client
+from hakoniwa_pdu.rpc.protocol_client import ProtocolClientImmediate
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
     AddTwoIntsRequest,
 )
@@ -38,7 +39,7 @@ async def run_rpc_client():
         req.a = 10
         req.b = 20
         print(f"\nCalling RPC: a={req.a}, b={req.b}")
-        res = protocol_client.call_nowait(req)
+        res = protocol_client.call(req)
         if res:
             print(f"Response received: sum={res.sum}")
         else:
@@ -50,7 +51,7 @@ async def run_rpc_client():
             req.a = res.sum
             req.b = 5
             print(f"\nCalling RPC: a={req.a}, b={req.b}")
-            res = protocol_client.call_nowait(req)
+            res = protocol_client.call(req)
             if res:
                 print(f"Response received: sum={res.sum}")
             else:
@@ -76,10 +77,11 @@ def my_on_initialize(context):
         service_name=SERVICE_NAME,
         client_name=CLIENT_NAME,
         srv="AddTwoInts",
+        ProtocolClientClass=ProtocolClientImmediate,
     )
     # クライアントをサービスに登録
     print(f"Registering client '{CLIENT_NAME}' to service '{SERVICE_NAME}'...")
-    if not protocol_client.register_nowait():
+    if not protocol_client.register():
         print("Failed to register client. Exiting.")
         return 1
     

--- a/examples/new_asset_server.py
+++ b/examples/new_asset_server.py
@@ -8,6 +8,7 @@ from hakoniwa_pdu.rpc.shm.shm_pdu_service_server_manager import (
     ShmPduServiceServerManager,
 )
 from hakoniwa_pdu.rpc.auto_wire import make_protocol_server
+from hakoniwa_pdu.rpc.protocol_server import ProtocolServerImmediate
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
     AddTwoIntsRequest,
 )
@@ -50,9 +51,10 @@ def my_on_initialize(context):
         service_name=SERVICE_NAME,
         srv="AddTwoInts",
         max_clients=1,
+        ProtocolServerClass=ProtocolServerImmediate,
     )
     # サービスを開始
-    if not protocol_server.start_service_nowait():
+    if not protocol_server.start_service():
         print("Failed to start service.")
         return 1
 
@@ -67,7 +69,7 @@ def my_on_manual_timing_control(context):
     print("Server is running. Waiting for requests...")
     try:
         # サーバーのイベントループを開始
-        protocol_server.serve_nowait(add_two_ints_handler)
+        protocol_server.serve(add_two_ints_handler)
     except KeyboardInterrupt:
         print("\nServer stopped by user.")
     finally:

--- a/examples/remote_rpc_client.py
+++ b/examples/remote_rpc_client.py
@@ -10,6 +10,7 @@ from hakoniwa_pdu.rpc.remote.remote_pdu_service_client_manager import (
     RemotePduServiceClientManager,
 )
 from hakoniwa_pdu.rpc.auto_wire import make_protocol_client
+from hakoniwa_pdu.rpc.protocol_client import ProtocolClientBlocking
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
     AddTwoIntsRequest,
 )
@@ -43,6 +44,7 @@ async def main() -> None:
         service_name=SERVICE_NAME,
         client_name=CLIENT_NAME,
         srv="AddTwoInts",
+        ProtocolClientClass=ProtocolClientBlocking,
     )
 
     if not await client.start_service(args.uri):

--- a/examples/remote_rpc_server.py
+++ b/examples/remote_rpc_server.py
@@ -12,6 +12,7 @@ from hakoniwa_pdu.rpc.remote.remote_pdu_service_server_manager import (
     RemotePduServiceServerManager,
 )
 from hakoniwa_pdu.rpc.auto_wire import make_protocol_server
+from hakoniwa_pdu.rpc.protocol_server import ProtocolServerBlocking
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
     AddTwoIntsRequest,
 )
@@ -55,6 +56,7 @@ async def main() -> None:
         service_name=SERVICE_NAME,
         srv="AddTwoInts",
         max_clients=1,
+        ProtocolServerClass=ProtocolServerBlocking,
     )
 
     if not await server.start_service():

--- a/src/hakoniwa_pdu/rpc/protocol_client.py
+++ b/src/hakoniwa_pdu/rpc/protocol_client.py
@@ -1,19 +1,19 @@
 import asyncio
-
+import time
 from typing import Any, Callable, Type, Optional, Union
+
 from .ipdu_service_manager import (
     IPduServiceClientManagerImmediate,
     IPduServiceClientManagerBlocking,
     ClientId,
 )
-import time
+
 PduManagerType = Union[IPduServiceClientManagerImmediate, IPduServiceClientManagerBlocking]
 
 
-class ProtocolClient:
-    """
-    IPduServiceManagerを介してクライアントのRPCプロトコルを処理するクラス。
-    """
+class ProtocolClientBase:
+    """Common functionality for RPC protocol clients."""
+
     def __init__(
         self,
         pdu_manager: PduManagerType,
@@ -25,18 +25,7 @@ class ProtocolClient:
         cls_res_packet: Type[Any],
         res_encoder: Callable,
         res_decoder: Callable,
-    ):
-        """
-        クライアントプロトコルハンドラを初期化する。
-
-        Args:
-            pdu_manager: IPduServiceManagerを実装したインスタンス。
-            service_name: 接続先のサービス名。
-            client_name: このクライアントの名称。
-            req_encoder: リクエストPDUをエンコードする関数 (dict -> bytes)。
-            req_decoder: リクエストPDUをデコードする関数 (bytes -> dict)。
-            res_decoder: レスポンスPDUをデコードする関数 (bytes -> dict)。
-        """
+    ) -> None:
         self.pdu_manager = pdu_manager
         self.service_name = service_name
         self.client_name = client_name
@@ -49,208 +38,191 @@ class ProtocolClient:
         self.client_id: Optional[ClientId] = None
         self._client_instance_request_id_counter = 0
         self._client_instance_last_request_id = -1
-        self.pdu_manager.register_req_serializer(cls_req_packet, req_encoder, req_decoder)
-        self.pdu_manager.register_res_serializer(cls_res_packet, res_encoder, res_decoder)
-
-
-    async def start_service(self, uri: str) -> bool:
-        return await self.pdu_manager.start_service(uri=uri)
-
-    def register_nowait(self) -> bool:
-        """
-        クライアントをサービスに登録する。リクエスト送信前に呼び出す必要がある。
-
-        Returns:
-            登録に成功した場合はTrue。
-        """
-        self.client_id = self.pdu_manager.register_client(self.service_name, self.client_name)
-        if self.client_id is not None:
-            print(f"Client '{self.client_name}' registered with service '{self.service_name}' (ID: {self.client_id})")
-            return True
-        else:
-            print(f"Failed to register client '{self.client_name}'")
-            return False
-
-    async def register(self) -> bool:
-        """
-        クライアントをサービスに登録する。リクエスト送信前に呼び出す必要がある。
-
-        Returns:
-            登録に成功した場合はTrue。
-        """
-        self.client_id = await self.pdu_manager.register_client(self.service_name, self.client_name)
-        if self.client_id is not None:
-            print(f"Client '{self.client_name}' registered with service '{self.service_name}' (ID: {self.client_id})")
-            return True
-        else:
-            print(f"Failed to register client '{self.client_name}'")
-            return False
-
+        self.pdu_manager.register_req_serializer(
+            cls_req_packet, req_encoder, req_decoder
+        )
+        self.pdu_manager.register_res_serializer(
+            cls_res_packet, res_encoder, res_decoder
+        )
 
     def _create_request_packet(self, request_data: Any, poll_interval: float) -> bytes:
         if self.client_id is None:
             raise RuntimeError("Client is not registered. Call register() first.")
 
-        request_id_to_pass = -1 # デフォルト値
-        
-        # remoteの場合: ProtocolClientがIDを生成して渡す
+        request_id_to_pass = -1
         if self.pdu_manager.requires_external_request_id:
             current_request_id = self._client_instance_request_id_counter
             self._client_instance_request_id_counter += 1
             request_id_to_pass = current_request_id
-            # remoteの場合は、生成したIDを待つべきIDとして保存
             self._client_instance_last_request_id = current_request_id
 
         poll_interval_msec = int(poll_interval * 1000)
         byte_array = self.pdu_manager.get_request_buffer(
-            self.client_id, self.pdu_manager.CLIENT_API_OPCODE_REQUEST, poll_interval_msec, request_id=request_id_to_pass)
-        
+            self.client_id,
+            self.pdu_manager.CLIENT_API_OPCODE_REQUEST,
+            poll_interval_msec,
+            request_id=request_id_to_pass,
+        )
+
         if byte_array is None:
             raise Exception("Failed to get request byte array")
 
         req_packet = self.req_decoder(byte_array)
 
-        # shmの場合: Cライブラリが設定したIDをバッファから読み取り、待つべきIDとして保存
         if not self.pdu_manager.requires_external_request_id:
             self._client_instance_last_request_id = req_packet.header.request_id
-        
-        # リクエストボディを設定してエンコード
+
         req_packet.body = request_data
         req_pdu_data = self.req_encoder(req_packet)
         return req_pdu_data
 
+
+class ProtocolClientBlocking(ProtocolClientBase):
+    """Blocking (async/await) RPC protocol client."""
+
+    async def start_service(self, uri: str) -> bool:
+        return await self.pdu_manager.start_service(uri=uri)
+
+    async def register(self) -> bool:
+        self.client_id = await self.pdu_manager.register_client(
+            self.service_name, self.client_name
+        )
+        if self.client_id is not None:
+            print(
+                f"Client '{self.client_name}' registered with service '{self.service_name}' (ID: {self.client_id})"
+            )
+            return True
+        print(f"Failed to register client '{self.client_name}'")
+        return False
+
     async def _wait_response(self) -> tuple[bool, Any]:
         while True:
-            #print(f'Polling for response...')
             event = self.pdu_manager.poll_response(self.client_id)
-
             if self.pdu_manager.is_client_event_response_in(event):
-                print(f"Response received successfully.")
-                res_pdu_data = self.pdu_manager.get_response(self.service_name, self.client_id)
+                res_pdu_data = self.pdu_manager.get_response(
+                    self.service_name, self.client_id
+                )
                 response_data = self.res_decoder(res_pdu_data)
-                
-                if response_data.header.request_id != self._client_instance_last_request_id:
-                    print(f"Warning: Mismatched request_id. Expected {self._client_instance_last_request_id}, got {response_data.header.request_id}. Discarding.")
+                if (
+                    response_data.header.request_id
+                    != self._client_instance_last_request_id
+                ):
+                    print(
+                        f"Warning: Mismatched request_id. Expected {self._client_instance_last_request_id}, got {response_data.header.request_id}. Discarding."
+                    )
                     continue
-
-                print(f"Decoded response data: {response_data}")
                 return False, response_data.body
-            
             if self.pdu_manager.is_client_event_timeout(event):
-                print("Request timed out.")
                 return True, None
-
             if self.pdu_manager.is_client_event_cancel_done(event):
-                print("Request successfully cancelled.")
                 return False, None
-            
             if self.pdu_manager.is_client_event_none(event):
                 await asyncio.sleep(0.01)
 
-
-
-    def _wait_response_nowait(self) -> tuple[bool, Any]:
-        while True:
-            #print(f'Polling for response...')
-            event = self.pdu_manager.poll_response(self.client_id)
-
-            if self.pdu_manager.is_client_event_response_in(event):
-                print(f"Response received successfully.")
-                res_pdu_data = self.pdu_manager.get_response(self.service_name, self.client_id)
-                response_data = self.res_decoder(res_pdu_data)
-                
-                if response_data.header.request_id != self._client_instance_last_request_id:
-                    print(f"Warning: Mismatched request_id. Expected {self._client_instance_last_request_id}, got {response_data.header.request_id}. Discarding.")
-                    continue
-
-                print(f"Decoded response data: {response_data}")
-                return False, response_data.body
-            
-            if self.pdu_manager.is_client_event_timeout(event):
-                print("Request timed out.")
-                return True, None
-
-            if self.pdu_manager.is_client_event_cancel_done(event):
-                print("Request successfully cancelled.")
-                return False, None
-            
-            if self.pdu_manager.is_client_event_none(event):
-                time.sleep(0.01)
-
-    async def call(self, request_data: Any, timeout_msec: int = 1000, poll_interval: float = 0.01) -> Any:
-        """
-        サービスに対して同期的な呼び出し（リクエスト-レスポンス）を行う。
-
-        Args:
-            request_data: 送信するリクエストデータ (dictなど)。
-            timeout_msec: タイムアウト（ミリ秒）。
-            poll_interval: イベントがない場合のポーリング間隔（秒）。
-
-        Returns:
-            レスポンスデータ。タイムアウトやエラーの場合はNoneを返す。
-        """
+    async def call(
+        self,
+        request_data: Any,
+        timeout_msec: int = 1000,
+        poll_interval: float = 0.01,
+    ) -> Any:
         req_pdu_data = self._create_request_packet(request_data, poll_interval)
 
-        if not await self.pdu_manager.call_request(self.client_id, req_pdu_data, timeout_msec):
+        if not await self.pdu_manager.call_request(
+            self.client_id, req_pdu_data, timeout_msec
+        ):
             print("Failed to send request.")
             return None
-        print(f"Request sent successfully: {request_data}")
-
 
         is_timeout, response_data = await self._wait_response()
         if is_timeout:
             await self.cancel()
             return None
         return response_data
-    
-    def call_nowait(self, request_data: Any, timeout_msec: int = 1000, poll_interval: float = 0.01) -> Any:
-        """
-        サービスに対して同期的な呼び出し（リクエスト-レスポンス）を行う。
-
-        Args:
-            request_data: 送信するリクエストデータ (dictなど)。
-            timeout_msec: タイムアウト（ミリ秒）。
-            poll_interval: イベントがない場合のポーリング間隔（秒）。
-
-        Returns:
-            レスポンスデータ。タイムアウトやエラーの場合はNoneを返す。
-        """
-        req_pdu_data = self._create_request_packet(request_data, poll_interval)
-
-        if not self.pdu_manager.call_request(self.client_id, req_pdu_data, timeout_msec):
-            print("Failed to send request.")
-            return None
-        print(f"Request sent successfully: {request_data}")
-
-
-        is_timeout, response_data = self._wait_response_nowait()
-        if is_timeout:
-            self.cancel_nowait()
-            return None
-        return response_data
 
     async def cancel(self) -> bool:
-        """
-        送信済みのリクエストのキャンセルを試みる。
-        """
         if self.client_id is None:
             raise RuntimeError("Client is not registered.")
-        
+
         if not await self.pdu_manager.cancel_request(self.client_id):
             raise Exception("Failed to cancel request.")
         _, _ = await self._wait_response()
         return True
 
-    def cancel_nowait(self) -> bool:
-        """
-        送信済みのリクエストのキャンセルを試みる。
-        """
+
+class ProtocolClientImmediate(ProtocolClientBase):
+    """Immediate (nowait) RPC protocol client."""
+
+    def start_service(self, uri: str) -> bool:
+        return self.pdu_manager.start_service_nowait(uri=uri)
+
+    def register(self) -> bool:
+        self.client_id = self.pdu_manager.register_client(
+            self.service_name, self.client_name
+        )
+        if self.client_id is not None:
+            print(
+                f"Client '{self.client_name}' registered with service '{self.service_name}' (ID: {self.client_id})"
+            )
+            return True
+        print(f"Failed to register client '{self.client_name}'")
+        return False
+
+    def _wait_response(self) -> tuple[bool, Any]:
+        while True:
+            event = self.pdu_manager.poll_response(self.client_id)
+            if self.pdu_manager.is_client_event_response_in(event):
+                res_pdu_data = self.pdu_manager.get_response(
+                    self.service_name, self.client_id
+                )
+                response_data = self.res_decoder(res_pdu_data)
+                if (
+                    response_data.header.request_id
+                    != self._client_instance_last_request_id
+                ):
+                    print(
+                        f"Warning: Mismatched request_id. Expected {self._client_instance_last_request_id}, got {response_data.header.request_id}. Discarding."
+                    )
+                    continue
+                return False, response_data.body
+            if self.pdu_manager.is_client_event_timeout(event):
+                return True, None
+            if self.pdu_manager.is_client_event_cancel_done(event):
+                return False, None
+            if self.pdu_manager.is_client_event_none(event):
+                time.sleep(0.01)
+
+    def call(
+        self,
+        request_data: Any,
+        timeout_msec: int = 1000,
+        poll_interval: float = 0.01,
+    ) -> Any:
+        req_pdu_data = self._create_request_packet(request_data, poll_interval)
+
+        if not self.pdu_manager.call_request(
+            self.client_id, req_pdu_data, timeout_msec
+        ):
+            print("Failed to send request.")
+            return None
+
+        is_timeout, response_data = self._wait_response()
+        if is_timeout:
+            self.cancel()
+            return None
+        return response_data
+
+    def cancel(self) -> bool:
         if self.client_id is None:
             raise RuntimeError("Client is not registered.")
 
         if not self.pdu_manager.cancel_request(self.client_id):
             raise Exception("Failed to cancel request.")
-        _, _ = self._wait_response_nowait()
+        _, _ = self._wait_response()
         return True
 
 
+__all__ = [
+    "ProtocolClientBase",
+    "ProtocolClientBlocking",
+    "ProtocolClientImmediate",
+]

--- a/src/hakoniwa_pdu/rpc/protocol_server.py
+++ b/src/hakoniwa_pdu/rpc/protocol_server.py
@@ -1,21 +1,24 @@
 import asyncio
 import time
 from typing import Callable, Awaitable, Any, Type, Union
+
 from .ipdu_service_manager import (
     IPduServiceServerManagerImmediate,
     IPduServiceServerManagerBlocking,
 )
 
-# リクエストハンドラの型定義: async def handler(request) -> response
+# Request handler type
 RequestHandler = Callable[[Any], Awaitable[Any]]
 
-PduManagerType = Union[IPduServiceServerManagerImmediate, IPduServiceServerManagerBlocking]
+PduManagerType = Union[
+    IPduServiceServerManagerImmediate,
+    IPduServiceServerManagerBlocking,
+]
 
 
-class ProtocolServer:
-    """
-    IPduServiceManagerを介してサーバーのRPCプロトコルを処理するクラス。
-    """
+class ProtocolServerBase:
+    """Common functionality for RPC protocol servers."""
+
     def __init__(
         self,
         service_name: str,
@@ -27,7 +30,7 @@ class ProtocolServer:
         cls_res_packet: Type[Any],
         res_encoder: Callable,
         res_decoder: Callable,
-    ):
+    ) -> None:
         self.service_name = service_name
         self.max_clients = max_clients
         self.pdu_manager = pdu_manager
@@ -38,100 +41,105 @@ class ProtocolServer:
         self.res_encoder = res_encoder
         self.res_decoder = res_decoder
         self._is_serving = False
-        self.pdu_manager.register_req_serializer(cls_req_packet, req_encoder, req_decoder)
-        self.pdu_manager.register_res_serializer(cls_res_packet, res_encoder, res_decoder)
-    
-    async def start_service(self) -> bool:
-        return await self.pdu_manager.start_rpc_service(self.service_name, max_clients=self.max_clients)
-    
-    def start_service_nowait(self) -> bool:
-        return self.pdu_manager.start_rpc_service(self.service_name, max_clients=self.max_clients)
+        self.pdu_manager.register_req_serializer(
+            cls_req_packet, req_encoder, req_decoder
+        )
+        self.pdu_manager.register_res_serializer(
+            cls_res_packet, res_encoder, res_decoder
+        )
 
-    async def _handle_request(self, client_id: Any, req_pdu_data: bytes, handler: RequestHandler) -> bytes:
-        """リクエスト処理の共通ロジック"""
+    async def _handle_request(
+        self, client_id: Any, req_pdu_data: bytes, handler: RequestHandler
+    ) -> bytes:
         request_data = self.req_decoder(req_pdu_data)
         response_data = await handler(request_data.body)
-        byte_array = self.pdu_manager.get_response_buffer(client_id, self.pdu_manager.API_STATUS_DONE, self.pdu_manager.API_RESULT_CODE_OK)
+        byte_array = self.pdu_manager.get_response_buffer(
+            client_id,
+            self.pdu_manager.API_STATUS_DONE,
+            self.pdu_manager.API_RESULT_CODE_OK,
+        )
         r = self.res_decoder(byte_array)
         r.body = response_data
         res_pdu_data = self.res_encoder(r)
         return res_pdu_data
 
-    async def serve(self, handler: RequestHandler, poll_interval: float = 0.01):
-        """
-        サーバーのメインイベントループを開始する (async版)。
-        """
-        self._is_serving = True
-        print("Server protocol started (async)...")
-        while self._is_serving:
-            print("[DEBUG] serve: polling request...")
-            event = await self.pdu_manager.poll_request()
-            print(f"[DEBUG] serve: polled event {event}")
 
+class ProtocolServerBlocking(ProtocolServerBase):
+    """Blocking (async/await) RPC protocol server."""
+
+    async def start_service(self) -> bool:
+        return await self.pdu_manager.start_rpc_service(
+            self.service_name, max_clients=self.max_clients
+        )
+
+    async def serve(
+        self, handler: RequestHandler, poll_interval: float = 0.01
+    ) -> None:
+        self._is_serving = True
+        while self._is_serving:
+            event = await self.pdu_manager.poll_request()
             if self.pdu_manager.is_server_event_request_in(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
-                print(f"Request received from client {client_id}")
                 try:
-                    res_pdu_data = await self._handle_request(client_id, req_pdu_data, handler)
+                    res_pdu_data = await self._handle_request(
+                        client_id, req_pdu_data, handler
+                    )
                     await self.pdu_manager.put_response(client_id, res_pdu_data)
-                    print(f"Response sent to client {client_id}")
                 except Exception as e:
                     print(f"Error processing request from client {client_id}: {e}")
-
             elif self.pdu_manager.is_server_event_cancel(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
-                print(f"Cancel request received from client {client_id}")
                 try:
                     await self.pdu_manager.put_cancel_response(client_id, None)
-                    print(f"Cancel response sent to client {client_id}")
                 except Exception as e:
                     print(f"Error processing cancel request from client {client_id}: {e}")
-
             elif self.pdu_manager.is_server_event_none(event):
-                print(f"[DEBUG] serve: no event poll_interval={poll_interval}")
                 await asyncio.sleep(poll_interval)
-                print(f"[DEBUG] serve: woke up from sleep")
-            
             else:
                 print(f"Unhandled server event: {event}")
 
-    def serve_nowait(self, handler: RequestHandler, poll_interval: float = 0.01):
-        """
-        サーバーのメインイベントループを開始する (nowait版)。
-        """
+    def stop(self) -> None:
+        self._is_serving = False
+
+
+class ProtocolServerImmediate(ProtocolServerBase):
+    """Immediate (nowait) RPC protocol server."""
+
+    def start_service(self) -> bool:
+        return self.pdu_manager.start_rpc_service(
+            self.service_name, max_clients=self.max_clients
+        )
+
+    def serve(self, handler: RequestHandler, poll_interval: float = 0.01) -> None:
         self._is_serving = True
-        print("Server protocol started (nowait)...")
         while self._is_serving:
             event = self.pdu_manager.poll_request()
-
             if self.pdu_manager.is_server_event_request_in(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
-                print(f"Request received from client {client_id}")
                 try:
-                    res_pdu_data = asyncio.run(self._handle_request(client_id, req_pdu_data, handler))
+                    res_pdu_data = asyncio.run(
+                        self._handle_request(client_id, req_pdu_data, handler)
+                    )
                     self.pdu_manager.put_response(client_id, res_pdu_data)
-                    print(f"Response sent to client {client_id}")
                 except Exception as e:
                     print(f"Error processing request from client {client_id}: {e}")
-
             elif self.pdu_manager.is_server_event_cancel(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
-                print(f"Cancel request received from client {client_id}")
                 try:
                     self.pdu_manager.put_cancel_response(client_id, None)
-                    print(f"Cancel response sent to client {client_id}")
                 except Exception as e:
                     print(f"Error processing cancel request from client {client_id}: {e}")
-
             elif self.pdu_manager.is_server_event_none(event):
                 time.sleep(poll_interval)
-            
             else:
                 print(f"Unhandled server event: {event}")
 
-    def stop(self):
-        """
-        サーバーのイベントループを停止する。
-        """
+    def stop(self) -> None:
         self._is_serving = False
-        print("Server protocol stopping...")
+
+
+__all__ = [
+    "ProtocolServerBase",
+    "ProtocolServerBlocking",
+    "ProtocolServerImmediate",
+]


### PR DESCRIPTION
## Summary
- Split protocol client into base, blocking (async) and immediate (sync) classes
- Split protocol server into base, blocking and immediate implementations
- Auto-select protocol classes in `auto_wire` and update examples to new APIs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa25e3676c83228f0a6c525704c05a