### PR TITLE
Support multi-service polling for protocol servers

### DIFF
--- a/src/hakoniwa_pdu/rpc/ipdu_service_manager.py
+++ b/src/hakoniwa_pdu/rpc/ipdu_service_manager.py
@@ -178,7 +178,11 @@ class IPduServiceServerManagerImmediate(IPduServiceServerManager):
         pass
 
     @abstractmethod
-    def poll_request(self) -> Event:
+    def poll_request(self) -> Tuple[Optional[str], Event]:
+        """チェックされたサービス名とイベントを返す。
+
+        処理中のリクエストが存在する場合は、他サービスのポーリングを行わず、
+        同一サービス名と ``NONE`` イベントのタプルを返す。"""
         pass
 
     @abstractmethod
@@ -218,7 +222,8 @@ class IPduServiceServerManagerBlocking(IPduServiceServerManager):
         pass
 
     @abstractmethod
-    async def poll_request(self) -> Event:
+    async def poll_request(self) -> Tuple[Optional[str], Event]:
+        """チェックされたサービス名とイベントを返す"""
         pass
 
     @abstractmethod

--- a/src/hakoniwa_pdu/rpc/protocol_server.py
+++ b/src/hakoniwa_pdu/rpc/protocol_server.py
@@ -1,19 +1,31 @@
 import asyncio
 import time
-from typing import Callable, Awaitable, Any, Type, Union
+from dataclasses import dataclass
+from typing import Callable, Awaitable, Any, Type, Union, Dict, Optional
 
 from .ipdu_service_manager import (
     IPduServiceServerManagerImmediate,
     IPduServiceServerManagerBlocking,
 )
 
-# Request handler type
 RequestHandler = Callable[[Any], Awaitable[Any]]
 
 PduManagerType = Union[
     IPduServiceServerManagerImmediate,
     IPduServiceServerManagerBlocking,
 ]
+
+
+@dataclass
+class _ServiceContext:
+    max_clients: int
+    cls_req_packet: Type[Any]
+    req_encoder: Callable
+    req_decoder: Callable
+    cls_res_packet: Type[Any]
+    res_encoder: Callable
+    res_decoder: Callable
+    handler: Optional[RequestHandler] = None
 
 
 class ProtocolServerBase:
@@ -31,36 +43,60 @@ class ProtocolServerBase:
         res_encoder: Callable,
         res_decoder: Callable,
     ) -> None:
-        self.service_name = service_name
-        self.max_clients = max_clients
         self.pdu_manager = pdu_manager
-        self.cls_req_packet = cls_req_packet
-        self.cls_res_packet = cls_res_packet
-        self.req_encoder = req_encoder
-        self.req_decoder = req_decoder
-        self.res_encoder = res_encoder
-        self.res_decoder = res_decoder
-        self._is_serving = False
-        self.pdu_manager.register_req_serializer(
-            cls_req_packet, req_encoder, req_decoder
+        self.service_name = service_name  # for backward compatibility
+        self._primary_service = service_name
+        self.services: Dict[str, _ServiceContext] = {}
+        self.add_service(
+            service_name,
+            max_clients,
+            cls_req_packet,
+            req_encoder,
+            req_decoder,
+            cls_res_packet,
+            res_encoder,
+            res_decoder,
         )
-        self.pdu_manager.register_res_serializer(
-            cls_res_packet, res_encoder, res_decoder
+        self._is_serving = False
+
+    def add_service(
+        self,
+        service_name: str,
+        max_clients: int,
+        cls_req_packet: Type[Any],
+        req_encoder: Callable,
+        req_decoder: Callable,
+        cls_res_packet: Type[Any],
+        res_encoder: Callable,
+        res_decoder: Callable,
+        handler: Optional[RequestHandler] = None,
+    ) -> None:
+        self.services[service_name] = _ServiceContext(
+            max_clients,
+            cls_req_packet,
+            req_encoder,
+            req_decoder,
+            cls_res_packet,
+            res_encoder,
+            res_decoder,
+            handler,
         )
 
     async def _handle_request(
-        self, client_id: Any, req_pdu_data: bytes, handler: RequestHandler
+        self, ctx: _ServiceContext, client_id: Any, req_pdu_data: bytes
     ) -> bytes:
-        request_data = self.req_decoder(req_pdu_data)
-        response_data = await handler(request_data.body)
+        request_data = ctx.req_decoder(req_pdu_data)
+        if ctx.handler is None:
+            raise RuntimeError("No handler registered for service")
+        response_data = await ctx.handler(request_data.body)
         byte_array = self.pdu_manager.get_response_buffer(
             client_id,
             self.pdu_manager.API_STATUS_DONE,
             self.pdu_manager.API_RESULT_CODE_OK,
         )
-        r = self.res_decoder(byte_array)
+        r = ctx.res_decoder(byte_array)
         r.body = response_data
-        res_pdu_data = self.res_encoder(r)
+        res_pdu_data = ctx.res_encoder(r)
         return res_pdu_data
 
 
@@ -68,21 +104,67 @@ class ProtocolServerBlocking(ProtocolServerBase):
     """Blocking (async/await) RPC protocol server."""
 
     async def start_service(self) -> bool:
+        ctx = self.services[self._primary_service]
+        self.pdu_manager.register_req_serializer(
+            ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+        )
+        self.pdu_manager.register_res_serializer(
+            ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+        )
         return await self.pdu_manager.start_rpc_service(
-            self.service_name, max_clients=self.max_clients
+            self._primary_service, max_clients=ctx.max_clients
         )
 
+    async def start_services(self) -> bool:
+        for name, ctx in self.services.items():
+            self.pdu_manager.register_req_serializer(
+                ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+            )
+            self.pdu_manager.register_res_serializer(
+                ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+            )
+            if not await self.pdu_manager.start_rpc_service(
+                name, max_clients=ctx.max_clients
+            ):
+                return False
+        return True
+
     async def serve(
-        self, handler: RequestHandler, poll_interval: float = 0.01
+        self,
+        handlers: Union[RequestHandler, Dict[str, RequestHandler]],
+        poll_interval: float = 0.01,
     ) -> None:
+        if callable(handlers):
+            handlers = {self._primary_service: handlers}
+        for name, handler in handlers.items():
+            if name in self.services:
+                self.services[name].handler = handler
+            else:
+                raise RuntimeError(f"Handler specified for unknown service '{name}'")
+
         self._is_serving = True
         while self._is_serving:
-            event = await self.pdu_manager.poll_request()
+            service_name, event = await self.pdu_manager.poll_request()
+            ctx = self.services.get(service_name)
+            if ctx is None:
+                if self.pdu_manager.is_server_event_none(event):
+                    await asyncio.sleep(poll_interval)
+                else:
+                    print(f"Unhandled server event: {event}")
+                continue
+
+            self.pdu_manager.register_req_serializer(
+                ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+            )
+            self.pdu_manager.register_res_serializer(
+                ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+            )
+
             if self.pdu_manager.is_server_event_request_in(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
                 try:
                     res_pdu_data = await self._handle_request(
-                        client_id, req_pdu_data, handler
+                        ctx, client_id, req_pdu_data
                     )
                     await self.pdu_manager.put_response(client_id, res_pdu_data)
                 except Exception as e:
@@ -106,19 +188,67 @@ class ProtocolServerImmediate(ProtocolServerBase):
     """Immediate (nowait) RPC protocol server."""
 
     def start_service(self) -> bool:
+        ctx = self.services[self._primary_service]
+        self.pdu_manager.register_req_serializer(
+            ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+        )
+        self.pdu_manager.register_res_serializer(
+            ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+        )
         return self.pdu_manager.start_rpc_service(
-            self.service_name, max_clients=self.max_clients
+            self._primary_service, max_clients=ctx.max_clients
         )
 
-    def serve(self, handler: RequestHandler, poll_interval: float = 0.01) -> None:
+    def start_services(self) -> bool:
+        for name, ctx in self.services.items():
+            self.pdu_manager.register_req_serializer(
+                ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+            )
+            self.pdu_manager.register_res_serializer(
+                ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+            )
+            if not self.pdu_manager.start_rpc_service(
+                name, max_clients=ctx.max_clients
+            ):
+                return False
+        return True
+
+    def serve(
+        self,
+        handlers: Union[RequestHandler, Dict[str, RequestHandler]],
+        poll_interval: float = 0.01,
+    ) -> None:
+        if callable(handlers):
+            handlers = {self._primary_service: handlers}
+        for name, handler in handlers.items():
+            if name in self.services:
+                self.services[name].handler = handler
+            else:
+                raise RuntimeError(f"Handler specified for unknown service '{name}'")
+
         self._is_serving = True
         while self._is_serving:
-            event = self.pdu_manager.poll_request()
+            service_name, event = self.pdu_manager.poll_request()
+            ctx = self.services.get(service_name)
+            if ctx is None:
+                if self.pdu_manager.is_server_event_none(event):
+                    time.sleep(poll_interval)
+                else:
+                    print(f"Unhandled server event: {event}")
+                continue
+
+            self.pdu_manager.register_req_serializer(
+                ctx.cls_req_packet, ctx.req_encoder, ctx.req_decoder
+            )
+            self.pdu_manager.register_res_serializer(
+                ctx.cls_res_packet, ctx.res_encoder, ctx.res_decoder
+            )
+
             if self.pdu_manager.is_server_event_request_in(event):
                 client_id, req_pdu_data = self.pdu_manager.get_request()
                 try:
                     res_pdu_data = asyncio.run(
-                        self._handle_request(client_id, req_pdu_data, handler)
+                        self._handle_request(ctx, client_id, req_pdu_data)
                     )
                     self.pdu_manager.put_response(client_id, res_pdu_data)
                 except Exception as e:

--- a/src/hakoniwa_pdu/rpc/shm/shm_pdu_service_server_manager.py
+++ b/src/hakoniwa_pdu/rpc/shm/shm_pdu_service_server_manager.py
@@ -33,24 +33,32 @@ class ShmPduServiceServerManager(
         self.service_id_map[service_id] = service_name
         return True
 
-    def poll_request(self) -> Event:
+    def poll_request(self) -> Tuple[Optional[str], Event]:
         if not self.service_id_map:
             raise RuntimeError("No service started.")
 
-        self.sleep(self.delta_time_sec)
-        service_id = list(self.service_id_map.keys())[0]
+        # 処理中のリクエストがある場合は同じサービス名でNONEイベントを返す
+        if self.current_server_client_info:
+            return (
+                self.current_server_client_info.get("service_name"),
+                hakopy.HAKO_SERVICE_SERVER_API_EVENT_NONE,
+            )
 
-        event = hakopy.asset_service_server_poll(service_id)
-        if self.is_server_event_request_in(event) or self.is_server_event_cancel(event):
-            client_id = hakopy.asset_service_server_get_current_client_id(service_id)
-            req_id, res_id = hakopy.asset_service_server_get_current_channel_id(service_id)
-            self.current_server_client_info = {
-                "service_id": service_id,
-                "client_id": client_id,
-                "req_channel_id": req_id,
-                "res_channel_id": res_id,
-            }
-        return event
+        self.sleep(self.delta_time_sec)
+        for service_id, service_name in self.service_id_map.items():
+            event = hakopy.asset_service_server_poll(service_id)
+            if self.is_server_event_request_in(event) or self.is_server_event_cancel(event):
+                client_id = hakopy.asset_service_server_get_current_client_id(service_id)
+                req_id, res_id = hakopy.asset_service_server_get_current_channel_id(service_id)
+                self.current_server_client_info = {
+                    "service_id": service_id,
+                    "service_name": service_name,
+                    "client_id": client_id,
+                    "req_channel_id": req_id,
+                    "res_channel_id": res_id,
+                }
+                return service_name, event
+        return None, hakopy.HAKO_SERVICE_SERVER_API_EVENT_NONE
 
     def get_response_buffer(
         self, client_id: ClientId, status: int, result_code: int
@@ -73,11 +81,17 @@ class ShmPduServiceServerManager(
 
     def put_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
         service_id = self.current_server_client_info.get("service_id")
-        return hakopy.asset_service_server_put_response(service_id, pdu_data)
+        ret = hakopy.asset_service_server_put_response(service_id, pdu_data)
+        if ret:
+            self.current_server_client_info = {}
+        return ret
 
     def put_cancel_response(self, client_id: ClientId, pdu_data: PduData) -> bool:
         service_id = self.current_server_client_info.get("service_id")
-        return hakopy.asset_service_client_cancel_request(service_id, client_id)
+        ret = hakopy.asset_service_client_cancel_request(service_id, client_id)
+        if ret:
+            self.current_server_client_info = {}
+        return ret
 
     # --- サーバーイベント種別判定 ---
     def is_server_event_request_in(self, event: Event) -> bool:


### PR DESCRIPTION
## Summary
- let server managers report service name alongside events to route requests
- track active client/service pair and pause polling other services until response or cancellation completes
- dispatch ProtocolServer requests based on reported service
- document poll_request behaviour for ongoing requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2cd4444c8322a4ce427a5a6c63e4