### PR TITLE
Add multi-service wire utilities and SystemControl RPC tests

### DIFF
--- a/examples/service.json
+++ b/examples/service.json
@@ -16,6 +16,21 @@
                     "baseSize": 288
                 }
             }
+        },
+        {
+            "name": "Service/SystemControl",
+            "type": "hako_srv_msgs/SystemControl",
+            "maxClients": 1,
+            "pduSize": {
+                "server": {
+                    "heapSize": 0,
+                    "baseSize": 280
+                },
+                "client": {
+                    "heapSize": 0,
+                    "baseSize": 408
+                }
+            }
         }
     ],
     "nodes": [

--- a/src/hakoniwa_pdu/rpc/protocol_client.py
+++ b/src/hakoniwa_pdu/rpc/protocol_client.py
@@ -49,6 +49,18 @@ class ProtocolClientBase:
         if self.client_id is None:
             raise RuntimeError("Client is not registered. Call register() first.")
 
+        self.pdu_manager.register_req_serializer(
+            self.cls_req_packet, self.req_encoder, self.req_decoder
+        )
+        self.pdu_manager.register_res_serializer(
+            self.cls_res_packet, self.res_encoder, self.res_decoder
+        )
+        # Ensure the manager uses the correct service/client identifiers
+        if hasattr(self.pdu_manager, "service_name"):
+            self.pdu_manager.service_name = self.service_name
+        if hasattr(self.pdu_manager, "client_name"):
+            self.pdu_manager.client_name = self.client_name
+
         request_id_to_pass = -1
         if self.pdu_manager.requires_external_request_id:
             current_request_id = self._client_instance_request_id_counter

--- a/src/hakoniwa_pdu/rpc/protocol_server.py
+++ b/src/hakoniwa_pdu/rpc/protocol_server.py
@@ -81,6 +81,8 @@ class ProtocolServerBase:
             res_decoder,
             handler,
         )
+        if hasattr(self.pdu_manager, "req_decoders"):
+            self.pdu_manager.req_decoders[service_name] = req_decoder
 
     async def _handle_request(
         self, ctx: _ServiceContext, client_id: Any, req_pdu_data: bytes

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import pytest
 from hakoniwa_pdu.impl.websocket_communication_service import WebSocketCommunicationService
 from hakoniwa_pdu.impl.websocket_server_communication_service import (
@@ -14,12 +13,20 @@ from hakoniwa_pdu.rpc.remote.remote_pdu_service_client_manager import (
 from hakoniwa_pdu.rpc.auto_wire import (
     make_protocol_client,
     make_protocol_server,
+    make_protocol_clients,
+    make_protocol_servers,
 )
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsRequest import (
     AddTwoIntsRequest,
 )
 from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_AddTwoIntsResponse import (
     AddTwoIntsResponse,
+)
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_SystemControlRequest import (
+    SystemControlRequest,
+)
+from hakoniwa_pdu.pdu_msgs.hako_srv_msgs.pdu_pytype_SystemControlResponse import (
+    SystemControlResponse,
 )
 
 OFFSET_PATH = "./tests/config/offset"
@@ -82,6 +89,170 @@ async def test_remote_rpc_call():
     assert res.sum == 30
 
     # 5. Cleanup
+    server_task.cancel()
+    await client_comm.stop_service()
+    await server_comm.stop_service()
+
+
+@pytest.mark.asyncio
+async def test_remote_multi_service_rpc_calls():
+    uri = "ws://localhost:8772"
+    pdu_config_path = "tests/pdu_config.json"
+    service_config_path = "examples/service.json"
+    offset_path = OFFSET_PATH
+
+    # Server setup with two services
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_pdu_manager = RemotePduServiceServerManager(
+        "test_server", pdu_config_path, offset_path, server_comm, uri
+    )
+    server_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_server = make_protocol_servers(
+        pdu_manager=server_pdu_manager,
+        services=[
+            {
+                "service_name": "Service/Add",
+                "srv": "AddTwoInts",
+                "max_clients": 1,
+            },
+            {
+                "service_name": "Service/SystemControl",
+                "srv": "SystemControl",
+                "max_clients": 1,
+            },
+        ],
+    )
+
+    async def add_handler(req: AddTwoIntsRequest) -> AddTwoIntsResponse:
+        res = AddTwoIntsResponse()
+        res.sum = req.a + req.b
+        return res
+
+    async def system_handler(req: SystemControlRequest) -> SystemControlResponse:
+        res = SystemControlResponse()
+        if req.opcode == 1:
+            res.status_code = 0
+            res.message = "OK"
+        else:
+            res.status_code = 1
+            res.message = "NG"
+        return res
+
+    await protocol_server.start_services()
+    server_task = asyncio.create_task(
+        protocol_server.serve(
+            {
+                "Service/Add": add_handler,
+                "Service/SystemControl": system_handler,
+            }
+        )
+    )
+
+    # Client setup with two services
+    client_comm = WebSocketCommunicationService(version="v2")
+    client_pdu_manager = RemotePduServiceClientManager(
+        "test_client", pdu_config_path, offset_path, client_comm, uri
+    )
+    client_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    clients = make_protocol_clients(
+        pdu_manager=client_pdu_manager,
+        services=[
+            {
+                "service_name": "Service/Add",
+                "client_name": "add_client",
+                "srv": "AddTwoInts",
+            },
+            {
+                "service_name": "Service/SystemControl",
+                "client_name": "ctrl_client",
+                "srv": "SystemControl",
+            },
+        ],
+    )
+
+    # Start communication and register both clients
+    first_client = next(iter(clients.values()))
+    assert await first_client.start_service(uri)
+    for client in clients.values():
+        assert await client.register()
+
+    # Call AddTwoInts service
+    add_req = AddTwoIntsRequest()
+    add_req.a = 7
+    add_req.b = 8
+    add_res = await clients["Service/Add"].call(add_req)
+    assert add_res is not None
+    assert add_res.sum == 15
+
+    # Call SystemControl service
+    ctrl_req = SystemControlRequest()
+    ctrl_req.opcode = 1
+    ctrl_res = await clients["Service/SystemControl"].call(ctrl_req)
+    assert ctrl_res is not None
+    assert ctrl_res.status_code == 0
+    assert ctrl_res.message == "OK"
+
+    # Cleanup
+    server_task.cancel()
+    await client_comm.stop_service()
+    await server_comm.stop_service()
+
+
+@pytest.mark.asyncio
+async def test_remote_system_control_rpc_call():
+    uri = "ws://localhost:8772"
+    pdu_config_path = "tests/pdu_config.json"
+    service_config_path = "examples/service.json"
+    offset_path = OFFSET_PATH
+
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_pdu_manager = RemotePduServiceServerManager(
+        "test_server", pdu_config_path, offset_path, server_comm, uri
+    )
+    server_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_server = make_protocol_server(
+        pdu_manager=server_pdu_manager,
+        service_name="Service/SystemControl",
+        srv="SystemControl",
+        max_clients=1,
+    )
+
+    async def handler(request: SystemControlRequest) -> SystemControlResponse:
+        response = SystemControlResponse()
+        if request.opcode == 1:
+            response.status_code = 0
+            response.message = "OK"
+        else:
+            response.status_code = 1
+            response.message = "NG"
+        return response
+
+    await protocol_server.start_service()
+    server_task = asyncio.create_task(protocol_server.serve(handler))
+
+    client_comm = WebSocketCommunicationService(version="v2")
+    client_pdu_manager = RemotePduServiceClientManager(
+        "test_client", pdu_config_path, offset_path, client_comm, uri
+    )
+    client_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_client = make_protocol_client(
+        pdu_manager=client_pdu_manager,
+        service_name="Service/SystemControl",
+        client_name="test_client",
+        srv="SystemControl",
+    )
+
+    assert await protocol_client.start_service(uri)
+    assert await protocol_client.register()
+
+    req = SystemControlRequest()
+    req.opcode = 1
+    res = await protocol_client.call(req)
+
+    assert res is not None
+    assert res.status_code == 0
+    assert res.message == "OK"
+
     server_task.cancel()
     await client_comm.stop_service()
     await server_comm.stop_service()


### PR DESCRIPTION
## Summary
- track service-specific request decoders in remote server manager to handle multiple RPC services concurrently
- propagate per-service decoders from ProtocolServer to the server manager
- add test exercising AddTwoInts and SystemControl services on the same server

## Testing
- `PYTHONPATH=src pytest tests/test_rpc.py::test_remote_rpc_call tests/test_rpc.py::test_remote_multi_service_rpc_calls tests/test_rpc.py::test_remote_system_control_rpc_call -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa3eacc6848322837772744af91e47