### PR TITLE
Add RPC cancel test

### DIFF
--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import pytest
 from hakoniwa_pdu.impl.websocket_communication_service import WebSocketCommunicationService
 from hakoniwa_pdu.impl.websocket_server_communication_service import (
@@ -92,6 +93,8 @@ async def test_remote_rpc_call():
     server_task.cancel()
     await client_comm.stop_service()
     await server_comm.stop_service()
+
+
 
 
 @pytest.mark.asyncio
@@ -254,5 +257,152 @@ async def test_remote_system_control_rpc_call():
     assert res.message == "OK"
 
     server_task.cancel()
+    await client_comm.stop_service()
+    await server_comm.stop_service()
+
+@pytest.mark.asyncio
+async def test_remote_rpc_cancel(capsys, request):
+    uri = "ws://localhost:8772"
+    pdu_config_path = "tests/pdu_config.json"
+    service_config_path = "examples/service.json"
+    offset_path = OFFSET_PATH
+
+    # --- Setup server and client ---
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_pdu_manager = RemotePduServiceServerManager(
+        "test_server", pdu_config_path, offset_path, server_comm, uri
+    )
+    server_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_server = make_protocol_server(
+        pdu_manager=server_pdu_manager,
+        service_name="Service/Add",
+        srv="AddTwoInts",
+        max_clients=1,
+    )
+    await protocol_server.start_service()
+
+    client_comm = WebSocketCommunicationService(version="v2")
+    client_pdu_manager = RemotePduServiceClientManager(
+        "test_client", pdu_config_path, offset_path, client_comm, uri
+    )
+    client_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_client = make_protocol_client(
+        pdu_manager=client_pdu_manager,
+        service_name="Service/Add",
+        client_name="test_client",
+        srv="AddTwoInts",
+    )
+
+    assert await protocol_client.start_service(uri)
+    assert await protocol_client.register()
+
+    # --- Send request that times out ---
+    req = AddTwoIntsRequest()
+    req.a = 1
+    req.b = 2
+    res = await protocol_client.call(req, timeout_msec=100)
+    assert res is None
+    await protocol_client.cancel()
+    await asyncio.sleep(0.1)
+
+    captured = capsys.readouterr()
+    assert "OKAH" in captured.out  # server log for cancel packet
+    print("cancel request processed")
+    client_pdu_manager.comm_buffer.clear()
+    server_pdu_manager.comm_buffer.clear()
+    captured = capsys.readouterr()
+    assert "cancel request processed" in captured.out
+
+    # --- Ensure subsequent request succeeds ---
+    async def add_handler(request: AddTwoIntsRequest) -> AddTwoIntsResponse:
+        res = AddTwoIntsResponse()
+        res.sum = request.a + request.b
+        return res
+
+    server_task = asyncio.create_task(protocol_server.serve(add_handler))
+    res2 = await protocol_client.call(req)
+    assert res2 is not None
+    assert res2.sum == 3
+
+    server_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await server_task
+    await client_comm.stop_service()
+    await server_comm.stop_service()
+
+
+@pytest.mark.asyncio
+async def test_remote_rpc_cancel_during_serving(capsys, request):
+    uri = "ws://localhost:8772"
+    pdu_config_path = "tests/pdu_config.json"
+    service_config_path = "examples/service.json"
+    offset_path = OFFSET_PATH
+
+    # --- Setup server with a slow handler ---
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_pdu_manager = RemotePduServiceServerManager(
+        "test_server", pdu_config_path, offset_path, server_comm, uri
+    )
+    server_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_server = make_protocol_server(
+        pdu_manager=server_pdu_manager,
+        service_name="Service/Add",
+        srv="AddTwoInts",
+        max_clients=1,
+    )
+
+    async def slow_handler(request: AddTwoIntsRequest) -> AddTwoIntsResponse:
+        await asyncio.sleep(0.2)  # longer than client timeout
+        res = AddTwoIntsResponse()
+        res.sum = request.a + request.b
+        return res
+
+    await protocol_server.start_service()
+    server_task = asyncio.create_task(protocol_server.serve(slow_handler))
+
+    # --- Setup client ---
+    client_comm = WebSocketCommunicationService(version="v2")
+    client_pdu_manager = RemotePduServiceClientManager(
+        "test_client", pdu_config_path, offset_path, client_comm, uri
+    )
+    client_pdu_manager.initialize_services(service_config_path, 1000 * 1000)
+    protocol_client = make_protocol_client(
+        pdu_manager=client_pdu_manager,
+        service_name="Service/Add",
+        client_name="test_client",
+        srv="AddTwoInts",
+    )
+
+    assert await protocol_client.start_service(uri)
+    assert await protocol_client.register()
+
+    # --- Send request that times out while handler runs ---
+    req = AddTwoIntsRequest()
+    req.a = 1
+    req.b = 2
+    res = await protocol_client.call(req, timeout_msec=100)
+    assert res is None
+    await protocol_client.cancel()
+    await asyncio.sleep(0.1)
+
+    captured = capsys.readouterr()
+    assert "OKAH" in captured.out  # server log for cancel packet
+    print("cancel request processed")
+    client_pdu_manager.comm_buffer.clear()
+    server_pdu_manager.comm_buffer.clear()
+    captured = capsys.readouterr()
+    assert "cancel request processed" in captured.out
+
+    # wait for slow handler to finish before retrying
+    await asyncio.sleep(0.2)
+
+    # --- Ensure subsequent request succeeds ---
+    res2 = await protocol_client.call(req)
+    assert res2 is not None
+    assert res2.sum == 3
+
+    server_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await server_task
     await client_comm.stop_service()
     await server_comm.stop_service()


### PR DESCRIPTION
## Summary
- add regression test for RPC cancel behavior when a call times out
- assert server logs cancel packet and subsequent retry succeeds
- cover cancelling while server handler is executing and verify next call responds

## Testing
- `PYTHONPATH=./src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa57d339908322b2f1e9b27eb87f7a