### PR TITLE
docs: outline PDU manager and RPC class layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,90 @@ python tests/sample.py \
 
 ```
 hakoniwa_pdu/
-├── pdu_manager.py                  # Manages PDU lifecycle
-├── impl/
-│   ├── websocket_communication_service.py  # WebSocket implementation
+├── pdu_manager.py                  # Core PDU manager
+├── impl/                           # Transport and utilities
+│   ├── icommunication_service.py   # Transport interface
+│   ├── websocket_communication_service.py      # WebSocket client
+│   ├── websocket_server_communication_service.py  # WebSocket server
+│   ├── shm_communication_service.py            # Shared memory transport
 │   ├── pdu_convertor.py            # Binary ⇔ JSON conversion
 │   ├── hako_binary/
 │   │   └── *.py (Handles offsets and binary layout)
+├── rpc/                            # RPC infrastructure
+│   ├── ipdu_service_manager.py     # Base classes for RPC managers
+│   ├── protocol_client.py          # High level RPC client helpers
+│   ├── protocol_server.py          # High level RPC server helpers
+│   ├── auto_wire.py                # Auto load protocol classes
+│   ├── remote/                     # RPC over WebSocket
+│   │   ├── remote_pdu_service_base_manager.py
+│   │   ├── remote_pdu_service_client_manager.py
+│   │   └── remote_pdu_service_server_manager.py
+│   └── shm/                        # RPC over shared memory
+│       ├── shm_pdu_service_base_manager.py
+│       ├── shm_pdu_service_client_manager.py
+│       └── shm_pdu_service_server_manager.py
 ├── resources/
 │   └── offset/                     # Offset definition files
+```
+
+## 🏗️ Class Overview
+
+### PduManager
+- `PduManager` orchestrates PDU buffers and delegates transport to an `ICommunicationService`.
+- Direct PDU I/O: declare channels with `declare_pdu_for_read/write` then use `flush_pdu_raw_data()` or `read_pdu_raw_data()`.
+- RPC usage: extended via `rpc.IPduServiceManager` to handle `register_client`, `start_rpc_service`, and other RPC-specific APIs.
+
+### Communication Implementations (`impl/`)
+- `ICommunicationService` defines the transport API.
+- `WebSocketCommunicationService` / `WebSocketServerCommunicationService` implement WebSocket transport.
+- `ShmCommunicationService` enables high-speed shared-memory transport.
+- Choose the backend by passing the desired implementation to `PduManager.initialize()`.
+
+### RPC Layer (`rpc/`)
+- `IPduServiceManager` family provides RPC APIs on top of `PduManager` with client/server variants and status codes.
+- `protocol_client.py` and `protocol_server.py` wrap these managers into user-friendly protocol classes.
+- `auto_wire.py` loads generated PDU converters and constructs protocol clients/servers automatically.
+- `remote/` contains WebSocket-based managers; `shm/` provides shared-memory managers.
+- `service_config.py` merges service definitions with base PDU definitions.
+
+## 🧭 Class Diagram
+
+```mermaid
+classDiagram
+    class PduManager
+    PduManager --> ICommunicationService : uses
+    PduManager --> CommunicationBuffer
+    PduManager --> PduConvertor
+    PduManager --> PduChannelConfig
+
+    class ICommunicationService {
+        <<interface>>
+    }
+    class WebSocketCommunicationService
+    class WebSocketServerCommunicationService
+    class ShmCommunicationService
+    ICommunicationService <|.. WebSocketCommunicationService
+    ICommunicationService <|.. WebSocketServerCommunicationService
+    ICommunicationService <|.. ShmCommunicationService
+
+    class IPduServiceManager {
+        <<abstract>>
+    }
+    PduManager <|-- IPduServiceManager
+    class IPduServiceClientManager
+    class IPduServiceServerManager
+    IPduServiceManager <|-- IPduServiceClientManager
+    IPduServiceManager <|-- IPduServiceServerManager
+
+    class RemotePduServiceBaseManager
+    RemotePduServiceBaseManager <|-- RemotePduServiceClientManager
+    RemotePduServiceBaseManager <|-- RemotePduServiceServerManager
+    IPduServiceManager <|-- RemotePduServiceBaseManager
+
+    class ShmPduServiceBaseManager
+    ShmPduServiceBaseManager <|-- ShmPduServiceClientManager
+    ShmPduServiceBaseManager <|-- ShmPduServiceServerManager
+    IPduServiceManager <|-- ShmPduServiceBaseManager
 ```
 
 ---


### PR DESCRIPTION
## Summary
- expand package structure to show transport and RPC modules
- document core PduManager usage, communication backends, and RPC layer
- add Mermaid class diagram for PduManager, transport services, and RPC managers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaede1f4648322b99453a021ebea70