### PR TITLE
Add client session management structure and regression tests

### DIFF
--- a/tests/test_websocket_communication_v2.py
+++ b/tests/test_websocket_communication_v2.py
@@ -54,6 +54,36 @@ async def test_websocket_client_server_communication_v2():
     await client_comm.stop_service()
     await server_comm.stop_service()
 
+
+@pytest.mark.asyncio
+async def test_websocket_client_disconnect_and_reconnect_v2():
+    uri = "ws://localhost:8771"
+    pdu_config_path = "tests/pdu_config.json"
+    pdu_channel_config = PduChannelConfig(pdu_config_path)
+
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await server_comm.start_service(server_buffer, uri) is True
+
+    first_client = WebSocketCommunicationService(version="v2")
+    first_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await first_client.start_service(first_buffer, uri) is True
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 1
+
+    await first_client.stop_service()
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 0
+
+    second_client = WebSocketCommunicationService(version="v2")
+    second_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await second_client.start_service(second_buffer, uri) is True
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 1
+
+    await second_client.stop_service()
+    await server_comm.stop_service()
+
 @pytest.mark.asyncio
 async def test_websocket_declare_pdu_for_read_v2():
     # 1. Setup


### PR DESCRIPTION
## Summary
- add `ClientSession` dataclass for tracking websocket client info
- store client sessions in `WebSocketServerCommunicationService`
- remove client sessions when websockets disconnect or send operations fail
- add regression tests for client reconnect, RPC timeout, and unimplemented cancel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba018af788322a141a8d8a2c0f609