### PR TITLE
Add targeted WebSocket server sends with connection hooks

### DIFF
--- a/src/hakoniwa_pdu/impl/websocket_base_communication_service.py
+++ b/src/hakoniwa_pdu/impl/websocket_base_communication_service.py
@@ -57,13 +57,19 @@ class WebSocketBaseCommunicationService(ICommunicationService):
     def get_server_uri(self) -> str:
         return self.uri
 
+    def _pack_pdu(
+        self, robot_name: str, channel_id: int, pdu_data: bytearray
+    ) -> bytearray:
+        """Pack PDU data into wire format."""
+        packet = DataPacket(robot_name, channel_id, pdu_data)
+        return packet.encode(self.version, meta_request_type=PDU_DATA)
+
     async def send_data(self, robot_name: str, channel_id: int, pdu_data: bytearray) -> bool:
         if not self.service_enabled or not self.websocket:
             print("[WARN] WebSocket not connected")
             return False
         try:
-            packet = DataPacket(robot_name, channel_id, pdu_data)
-            encoded = packet.encode(self.version, meta_request_type=PDU_DATA)
+            encoded = self._pack_pdu(robot_name, channel_id, pdu_data)
             await self.websocket.send(encoded)
             return True
         except Exception as e:

--- a/src/hakoniwa_pdu/impl/websocket_server_communication_service.py
+++ b/src/hakoniwa_pdu/impl/websocket_server_communication_service.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
 from urllib.parse import urlparse
 
 import websockets
@@ -9,12 +10,36 @@ from .communication_buffer import CommunicationBuffer
 from .websocket_base_communication_service import WebSocketBaseCommunicationService
 
 
+@dataclass
+class ClientSession:
+    """Session information for a connected WebSocket client."""
+
+    client_id: str
+    websocket: WebSocketServerProtocol
+    name: Optional[str] = None
+    send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
 class WebSocketServerCommunicationService(WebSocketBaseCommunicationService):
     """WebSocketベースのサーバ通信サービス."""
 
     def __init__(self, version: str = "v1"):
         super().__init__(version)
         self.server: Optional[websockets.server.Serve] = None
+        # Store active client sessions; still single-client by default
+        self.clients: Dict[str, ClientSession] = {}
+        self.on_connect: Callable[[str], None] = lambda cid: None
+        self.on_disconnect: Callable[[str], None] = lambda cid: None
+        self._id_seq: int = 0
+
+    def _next_client_id(self) -> str:
+        self._id_seq += 1
+        return f"ws{self._id_seq:06d}"
+
+    def _remove_client_by_id(self, client_id: str) -> None:
+        session = self.clients.pop(client_id, None)
+        if session and session.websocket is self.websocket:
+            self.websocket = None
 
     async def start_service(
         self,
@@ -69,11 +94,66 @@ class WebSocketServerCommunicationService(WebSocketBaseCommunicationService):
             await websocket.close()
             return
         self.websocket = websocket
+        client_id = self._next_client_id()
+        self.clients[client_id] = ClientSession(client_id, websocket)
         try:
+            try:
+                self.on_connect(client_id)
+            except Exception:
+                pass
             if self.version == "v1":
                 await self._receive_loop_v1(websocket)
             else:
                 await self._receive_loop_v2(websocket)
         finally:
-            self.websocket = None
+            self._remove_client_by_id(client_id)
+            try:
+                self.on_disconnect(client_id)
+            except Exception:
+                pass
+
+    async def send_binary_to(
+        self, client_id: str, raw_data: bytes | bytearray
+    ) -> bool:
+        session = self.clients.get(client_id)
+        if session is None:
+            return False
+        async with session.send_lock:
+            try:
+                await session.websocket.send(raw_data)
+                return True
+            except Exception as e:
+                print(f"[ERROR] Failed to send binary to {client_id}: {e}")
+                try:
+                    await session.websocket.close()
+                except Exception:
+                    pass
+                self._remove_client_by_id(client_id)
+                try:
+                    self.on_disconnect(client_id)
+                except Exception:
+                    pass
+                return False
+
+    async def send_data_to(
+        self, client_id: str, robot_name: str, channel_id: int, pdu_data: bytearray
+    ) -> bool:
+        raw = self._pack_pdu(robot_name, channel_id, pdu_data)
+        return await self.send_binary_to(client_id, raw)
+
+    async def send_data(
+        self, robot_name: str, channel_id: int, pdu_data: bytearray
+    ) -> bool:
+        if not self.clients:
+            print("[WARN] WebSocket not connected")
+            return False
+        client_id = next(iter(self.clients))
+        return await self.send_data_to(client_id, robot_name, channel_id, pdu_data)
+
+    async def send_binary(self, raw_data: bytearray) -> bool:
+        if not self.clients:
+            print("[WARN] WebSocket not connected")
+            return False
+        client_id = next(iter(self.clients))
+        return await self.send_binary_to(client_id, raw_data)
 

--- a/tests/test_websocket_communication_v2.py
+++ b/tests/test_websocket_communication_v2.py
@@ -54,6 +54,36 @@ async def test_websocket_client_server_communication_v2():
     await client_comm.stop_service()
     await server_comm.stop_service()
 
+
+@pytest.mark.asyncio
+async def test_websocket_client_disconnect_and_reconnect_v2():
+    uri = "ws://localhost:8771"
+    pdu_config_path = "tests/pdu_config.json"
+    pdu_channel_config = PduChannelConfig(pdu_config_path)
+
+    server_comm = WebSocketServerCommunicationService(version="v2")
+    server_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await server_comm.start_service(server_buffer, uri) is True
+
+    first_client = WebSocketCommunicationService(version="v2")
+    first_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await first_client.start_service(first_buffer, uri) is True
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 1
+
+    await first_client.stop_service()
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 0
+
+    second_client = WebSocketCommunicationService(version="v2")
+    second_buffer = CommunicationBuffer(pdu_channel_config)
+    assert await second_client.start_service(second_buffer, uri) is True
+    await asyncio.sleep(0.1)
+    assert len(server_comm.clients) == 1
+
+    await second_client.stop_service()
+    await server_comm.stop_service()
+
 @pytest.mark.asyncio
 async def test_websocket_declare_pdu_for_read_v2():
     # 1. Setup

--- a/tests/test_ws_server_comm.py
+++ b/tests/test_ws_server_comm.py
@@ -1,0 +1,88 @@
+import asyncio
+import socket
+
+import pytest
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from hakoniwa_pdu.impl.communication_buffer import CommunicationBuffer
+from hakoniwa_pdu.impl.pdu_channel_config import PduChannelConfig
+from hakoniwa_pdu.impl.websocket_server_communication_service import (
+    WebSocketServerCommunicationService,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _get_free_port() -> int:
+    s = socket.socket()
+    s.bind(("localhost", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _start_server():
+    port = _get_free_port()
+    host = "127.0.0.1"
+    uri = f"ws://{host}:{port}"
+    srv = WebSocketServerCommunicationService(version="v2")
+    pdu_config_path = "tests/pdu_config.json"
+    buf = CommunicationBuffer(PduChannelConfig(pdu_config_path))
+    connected: list[str] = []
+    disconnected: list[str] = []
+    srv.on_connect = lambda cid: connected.append(cid)
+    srv.on_disconnect = lambda cid: disconnected.append(cid)
+    assert await srv.start_service(buf, uri) is True
+    return srv, host, port, connected, disconnected
+
+
+async def test_single_connection_and_legacy_send():
+    srv, host, port, connected, disconnected = await _start_server()
+    uri = f"ws://{host}:{port}"
+    try:
+        async with websockets.connect(uri) as ws:
+            await asyncio.sleep(0.05)
+            assert len(connected) == 1
+            cid = connected[0]
+
+            data = b"ping"
+            ok = await srv.send_binary(bytearray(data))
+            assert ok
+            recv = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            assert recv == data
+
+            data2 = b"hello"
+            ok2 = await srv.send_binary_to(cid, data2)
+            assert ok2
+            recv2 = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            assert recv2 == data2
+
+        await asyncio.sleep(0.05)
+        assert disconnected == [cid]
+        assert await srv.send_binary_to(cid, b"more") is False
+    finally:
+        await srv.stop_service()
+
+
+async def test_unknown_client_id_send_fails():
+    srv, *_ = await _start_server()
+    try:
+        ok = await srv.send_binary_to("ws999999", b"x")
+        assert ok is False
+    finally:
+        await srv.stop_service()
+
+
+async def test_second_client_is_rejected():
+    srv, host, port, *_ = await _start_server()
+    uri = f"ws://{host}:{port}"
+    try:
+        async with websockets.connect(uri) as ws1:
+            with pytest.raises(ConnectionClosed):
+                async with websockets.connect(uri) as ws2:
+                    await ws2.recv()
+            await ws1.send(b"ok")
+    finally:
+        await srv.stop_service()
+


### PR DESCRIPTION
## Summary
- add `_pack_pdu` helper and use it for all WebSocket PDU encoding
- support client-specific sends with connection/disconnect callbacks and id management
- test server `send_binary_to` API and single-client enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba018af788322a141a8d8a2c0f609