### PR TITLE
Support PDU broadcasting to multiple subscribers

### DIFF
--- a/tests/test_declared_read_registry.py
+++ b/tests/test_declared_read_registry.py
@@ -43,9 +43,11 @@ async def test_declare_registry_and_cleanup():
     await asyncio.sleep(0.1)
 
     assert ("robot", 1) in server_mgr._declared_read.get(cid, set())
+    assert cid in server_mgr._read_index.get(("robot", 1), set())
 
     await client_comm.stop_service()
     await asyncio.sleep(0.1)
     assert cid not in server_mgr._declared_read
+    assert cid not in server_mgr._read_index.get(("robot", 1), set())
 
     await server_comm.stop_service()

--- a/tests/test_publish_pdu.py
+++ b/tests/test_publish_pdu.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from hakoniwa_pdu.impl.data_packet import DataPacket, DECLARE_PDU_FOR_READ
+from hakoniwa_pdu.rpc.remote.remote_pdu_service_server_manager import RemotePduServiceServerManager
+
+
+class MockCommService:
+    version = "v2"
+
+    def __init__(self):
+        self.calls = []
+        self.fail_clients = set()
+        self.on_disconnect = None
+
+    def set_channel_config(self, _cfg):
+        pass
+
+    def register_event_handler(self, handler):
+        self.handler = handler
+
+    async def send_data_to(self, client_id, robot_name, channel_id, data):
+        self.calls.append((client_id, robot_name, channel_id, bytes(data)))
+        return client_id not in self.fail_clients
+
+
+pdu_config_path = "tests/pdu_config.json"
+offset_path = "tests/config/offset"
+uri = "ws://localhost"
+
+pytestmark = pytest.mark.asyncio
+
+
+def _declare(manager, cid, robot="R", ch=1):
+    pkt = DataPacket(robot, ch, bytearray())
+    pkt.meta_pdu.meta_request_type = DECLARE_PDU_FOR_READ
+    return manager.handler(pkt, cid)
+
+
+async def _make_manager():
+    comm = MockCommService()
+    mgr = RemotePduServiceServerManager("srv", pdu_config_path, offset_path, comm, uri)
+    mgr.register_handler_pdu_for_read(lambda cid, pkt: None)
+    return mgr, comm
+
+
+async def test_publish_multiple_clients():
+    mgr, comm = await _make_manager()
+    await _declare(mgr, "c1")
+    await _declare(mgr, "c2")
+    sent = await mgr.publish_pdu("R", 1, b"abc")
+    assert sent == 2
+    assert comm.calls == [
+        ("c1", "R", 1, b"abc"),
+        ("c2", "R", 1, b"abc"),
+    ]
+
+
+async def test_duplicate_declare_single_send():
+    mgr, comm = await _make_manager()
+    await _declare(mgr, "c1")
+    await _declare(mgr, "c1")
+    sent = await mgr.publish_pdu("R", 1, b"abc")
+    assert sent == 1
+    assert comm.calls == [("c1", "R", 1, b"abc")]
+
+
+async def test_publish_no_subscribers():
+    mgr, comm = await _make_manager()
+    sent = await mgr.publish_pdu("R", 999, b"x")
+    assert sent == 0
+    assert comm.calls == []
+
+
+async def test_disconnect_cleanup():
+    mgr, comm = await _make_manager()
+    await _declare(mgr, "c1")
+    await _declare(mgr, "c2")
+    mgr.on_disconnect("c1")
+    sent = await mgr.publish_pdu("R", 1, b"abc")
+    assert sent == 1
+    assert comm.calls == [("c2", "R", 1, b"abc")]
+    assert mgr._read_index.get(("R", 1)) == {"c2"}
+
+
+async def test_send_failure():
+    mgr, comm = await _make_manager()
+    await _declare(mgr, "c1")
+    await _declare(mgr, "c2")
+    comm.fail_clients.add("c1")
+    sent = await mgr.publish_pdu("R", 1, b"abc")
+    assert sent == 1
+    assert comm.calls == [
+        ("c1", "R", 1, b"abc"),
+        ("c2", "R", 1, b"abc"),
+    ]


### PR DESCRIPTION
## Summary
- Track subscribers with forward and reverse indexes for efficient lookup and cleanup
- Broadcast PDUs to all clients declared for a topic via new `publish_pdu` API
- Add comprehensive unit tests for multi-client delivery, duplicate declarations, disconnect cleanup, and send failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbcc8cfd48322912e921dbc61c959