### PR TITLE
Add OS-independent Launcher background lifecycle control

### DIFF
--- a/docs/launcher-background-lifecycle.md
+++ b/docs/launcher-background-lifecycle.md
@@ -1,0 +1,46 @@
+# Hakoniwa Launcher background lifecycle
+
+The Launcher can be started in the background with an explicit session file. The session file is the caller-owned handle used for later lifecycle operations; callers do not need to know POSIX or Windows signal semantics.
+
+## Start
+
+```bash
+python -m hakoniwa_pdu.apps.launcher.hako_launcher path/to/launch.json \
+  --background ./run/launcher-session.json
+```
+
+The command returns only after the background Launcher has activated the assets, completed `hako-cmd start`, opened its localhost control endpoint, and written the session file.
+
+The Launcher writes its own stdout/stderr to `<session-file>.log` and prints a JSON summary containing the session path, PID, state, and log path.
+
+## Status
+
+```bash
+python -m hakoniwa_pdu.apps.launcher.hako_launcher_ctl \
+  status ./run/launcher-session.json
+```
+
+The command prints a JSON response such as:
+
+```json
+{"ok": true, "pid": 12345, "state": "RUNNING"}
+```
+
+## Terminate
+
+```bash
+python -m hakoniwa_pdu.apps.launcher.hako_launcher_ctl \
+  terminate ./run/launcher-session.json
+```
+
+`terminate` calls the running Launcher's `LauncherService.terminate()` through a localhost control endpoint. Child-process cleanup therefore remains owned by the Launcher, including the existing OS-specific process-group behavior.
+
+The session file is retained after termination with `state: "TERMINATED"` for post-run inspection.
+
+## Session ownership and stale files
+
+The session file contains the Launcher's PID, localhost control endpoint, and a random token. The control endpoint verifies both the token and expected PID before accepting lifecycle commands.
+
+If the session file is stale and the endpoint cannot be reached, `hako_launcher_ctl` reports `STALE` and does not fall back to killing the recorded PID. This avoids terminating an unrelated process after PID reuse.
+
+Starting with `--background` refuses to overwrite a live session. A terminal or unreachable stale session file at the same explicit path may be replaced by the new run.

--- a/src/hakoniwa_pdu/apps/launcher/hako_launcher.py
+++ b/src/hakoniwa_pdu/apps/launcher/hako_launcher.py
@@ -171,8 +171,12 @@ def _spawn_background(launch_file: str, session_file: str) -> int:
                     return 2
                 except LauncherControlError:
                     print(f"[launcher] replacing stale session file: {session_path}", file=sys.stderr)
-        except LauncherControlError:
-            print(f"[launcher] replacing unreadable session file: {session_path}", file=sys.stderr)
+        except LauncherControlError as exc:
+            print(
+                f"[launcher] refusing to overwrite unreadable session file: {session_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
         session_path.unlink(missing_ok=True)
 
     command = [
@@ -426,4 +430,4 @@ async def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(asyncio.run(main()))

--- a/src/hakoniwa_pdu/apps/launcher/hako_launcher.py
+++ b/src/hakoniwa_pdu/apps/launcher/hako_launcher.py
@@ -6,12 +6,26 @@ import signal
 import threading
 import time
 import asyncio
+import json
 import logging
+import subprocess
+from pathlib import Path
 from typing import Optional
 
 from .loader import load
 from .hako_monitor import HakoMonitor
 from .hako_cli import HakoCli
+from .hako_launcher_background import (
+    LauncherControlError,
+    LauncherControlServer,
+    is_terminal_session,
+    read_session,
+    send_control_command,
+    write_session,
+)
+
+_BACKGROUND_READY_TIMEOUT_SEC = 60.0
+
 
 class LauncherService:
     """起動・監視・停止を状態付きで提供。"""
@@ -103,16 +117,191 @@ class LauncherService:
             self.state = "TERMINATED"
             self._stop_watch.set()
 
-# -------- CLI エントリ --------
+
+# -------- background lifecycle --------
+
+def _background_log_path(session_file: Path) -> Path:
+    return Path(f"{session_file}.log")
+
 
 def _install_sigint(service: LauncherService):
-    def _sigint_handler(signum, frame):
-        print("[launcher] SIGINT received → aborting...")
+    def _signal_handler(signum, frame):
+        print(f"[launcher] signal({signum}) received → aborting...")
         try:
             service.terminate()
         finally:
             sys.exit(1)
-    signal.signal(signal.SIGINT, _sigint_handler)
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    if hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, _signal_handler)
+
+
+def _stop_background_process(proc: subprocess.Popen) -> None:
+    try:
+        if os.name == "nt" and hasattr(signal, "CTRL_BREAK_EVENT"):
+            proc.send_signal(signal.CTRL_BREAK_EVENT)
+        else:
+            proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=5)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def _spawn_background(launch_file: str, session_file: str) -> int:
+    launch_path = Path(launch_file).expanduser().resolve()
+    session_path = Path(session_file).expanduser().resolve()
+    log_path = _background_log_path(session_path)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if session_path.exists():
+        try:
+            existing = read_session(session_path)
+            if not is_terminal_session(existing):
+                try:
+                    response = send_control_command(session_path, "status", timeout_sec=1.0)
+                    print(
+                        f"[launcher] background session is already active: "
+                        f"{session_path} (state={response.get('state')})",
+                        file=sys.stderr,
+                    )
+                    return 2
+                except LauncherControlError:
+                    print(f"[launcher] replacing stale session file: {session_path}", file=sys.stderr)
+        except LauncherControlError:
+            print(f"[launcher] replacing unreadable session file: {session_path}", file=sys.stderr)
+        session_path.unlink(missing_ok=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        "hakoniwa_pdu.apps.launcher.hako_launcher",
+        str(launch_path),
+        "--_background-worker",
+        str(session_path),
+    ]
+    popen_kwargs = {
+        "stdin": subprocess.DEVNULL,
+        "stderr": subprocess.STDOUT,
+        "close_fds": True,
+    }
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    with log_path.open("w", encoding="utf-8") as log_stream:
+        popen_kwargs["stdout"] = log_stream
+        try:
+            proc = subprocess.Popen(command, **popen_kwargs)
+        except OSError as exc:
+            print(f"[launcher] failed to start background launcher: {exc}", file=sys.stderr)
+            return 1
+
+    deadline = time.monotonic() + _BACKGROUND_READY_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        if session_path.exists():
+            try:
+                session = read_session(session_path)
+                state = str(session.get("state", "UNKNOWN"))
+                if state == "FAILED":
+                    print(
+                        f"[launcher] background launcher failed: {session.get('error', 'unknown error')} "
+                        f"(log={log_path})",
+                        file=sys.stderr,
+                    )
+                    return 1
+                response = send_control_command(session_path, "status", timeout_sec=1.0)
+                print(
+                    json.dumps(
+                        {
+                            "session_file": str(session_path),
+                            "pid": response.get("pid"),
+                            "state": response.get("state"),
+                            "log_file": str(log_path),
+                        }
+                    )
+                )
+                return 0
+            except LauncherControlError:
+                pass
+        rc = proc.poll()
+        if rc is not None:
+            print(
+                f"[launcher] background launcher exited before becoming ready: rc={rc} "
+                f"(log={log_path})",
+                file=sys.stderr,
+            )
+            return 1
+        time.sleep(0.1)
+
+    print(
+        f"[launcher] timed out waiting for background launcher readiness "
+        f"(log={log_path})",
+        file=sys.stderr,
+    )
+    _stop_background_process(proc)
+    return 1
+
+
+def _write_failed_session(
+    session_file: Path,
+    launch_file: Path,
+    log_file: Path,
+    error: str,
+) -> None:
+    write_session(
+        session_file,
+        {
+            "version": 1,
+            "pid": os.getpid(),
+            "launch_file": str(launch_file),
+            "log_file": str(log_file),
+            "state": "FAILED",
+            "error": error,
+        },
+    )
+
+
+def _run_background_worker(
+    service: LauncherService,
+    launch_file: str,
+    session_file: str,
+) -> int:
+    session_path = Path(session_file).expanduser().resolve()
+    launch_path = Path(launch_file).expanduser().resolve()
+    log_path = _background_log_path(session_path)
+    server: LauncherControlServer | None = None
+    try:
+        service.activate()
+        rc = service.cmd("start")
+        if rc != 0:
+            raise RuntimeError(f"hako-cmd start failed with rc={rc}")
+        server = LauncherControlServer(
+            service=service,
+            session_path=session_path,
+            launch_file=launch_path,
+            log_file=log_path,
+        )
+        server.serve_until_terminated()
+        return 0
+    except Exception as exc:
+        try:
+            service.terminate()
+        except Exception:
+            pass
+        _write_failed_session(session_path, launch_path, log_path, str(exc))
+        print(f"[launcher] background worker failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if server is not None:
+            server.server_close()
+
+
+# -------- CLI エントリ --------
 
 async def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Hakoniwa Launcher")
@@ -125,7 +314,18 @@ async def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--no-watch", action="store_true",
                         help="(immediate時) 監視せず起動だけして終了")
+    parser.add_argument(
+        "--background",
+        metavar="SESSION_FILE",
+        help="Launch in the background and write lifecycle control information to SESSION_FILE",
+    )
+    parser.add_argument("--_background-worker", metavar="SESSION_FILE", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
+
+    if args.background is not None:
+        if args.mode != "immediate" or args.no_watch:
+            parser.error("--background cannot be combined with --mode or --no-watch")
+        return _spawn_background(args.launch_file, args.background)
 
     # Setup logging
     if os.environ.get('HAKO_PDU_DEBUG') == '1':
@@ -142,6 +342,15 @@ async def main(argv: list[str] | None = None) -> int:
     try:
         service = LauncherService(launch_path=args.launch_file)
     except Exception as e:
+        if args._background_worker is not None:
+            session_path = Path(args._background_worker).expanduser().resolve()
+            launch_path = Path(args.launch_file).expanduser().resolve()
+            _write_failed_session(
+                session_path,
+                launch_path,
+                _background_log_path(session_path),
+                f"failed to load spec: {e}",
+            )
         print(f"[launcher] Failed to load spec: {e}", file=sys.stderr)
         return 1
 
@@ -150,6 +359,9 @@ async def main(argv: list[str] | None = None) -> int:
     print("[INFO] HakoLauncher ready. assets:")
     for a in service.spec.assets:
         print(f" - {a.name} (cwd={a.cwd}, cmd={a.command}, args={a.args})")
+
+    if args._background_worker is not None:
+        return _run_background_worker(service, args.launch_file, args._background_worker)
 
     if args.mode == "immediate":
         try:
@@ -211,6 +423,7 @@ async def main(argv: list[str] | None = None) -> int:
                 print(f"[serve] error: {e}", file=sys.stderr)
 
     return 0
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/hakoniwa_pdu/apps/launcher/hako_launcher_background.py
+++ b/src/hakoniwa_pdu/apps/launcher/hako_launcher_background.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import socket
+import socketserver
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+SESSION_VERSION = 1
+DEFAULT_CONTROL_HOST = "127.0.0.1"
+_TERMINAL_STATES = {"TERMINATED", "FAILED"}
+_MAX_REQUEST_BYTES = 64 * 1024
+
+
+class LauncherLifecycle(Protocol):
+    def terminate(self) -> None: ...
+    def status(self) -> str: ...
+
+
+class LauncherControlError(RuntimeError):
+    pass
+
+
+def _path(value: str | os.PathLike[str]) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def read_session(path: str | os.PathLike[str]) -> dict[str, Any]:
+    session_path = _path(path)
+    try:
+        data = json.loads(session_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise LauncherControlError(f"session file not found: {session_path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LauncherControlError(f"cannot read session file {session_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise LauncherControlError(f"invalid session file: {session_path}")
+    return data
+
+
+def write_session(path: str | os.PathLike[str], payload: dict[str, Any]) -> Path:
+    session_path = _path(path)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{session_path.name}.",
+        suffix=".tmp",
+        dir=session_path.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, session_path)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return session_path
+
+
+def is_terminal_session(data: dict[str, Any]) -> bool:
+    return str(data.get("state", "")).upper() in _TERMINAL_STATES
+
+
+class _ControlHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        server = self.server
+        if not isinstance(server, LauncherControlServer):
+            return
+        raw = self.rfile.readline(_MAX_REQUEST_BYTES)
+        if not raw:
+            return
+        try:
+            request = json.loads(raw.decode("utf-8"))
+            response = server.dispatch(request)
+        except Exception as exc:
+            response = {"ok": False, "error": str(exc), "pid": os.getpid()}
+        self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
+        self.wfile.flush()
+
+
+class LauncherControlServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        *,
+        service: LauncherLifecycle,
+        session_path: str | os.PathLike[str],
+        launch_file: str | os.PathLike[str],
+        log_file: str | os.PathLike[str],
+        token: str | None = None,
+    ) -> None:
+        super().__init__((DEFAULT_CONTROL_HOST, 0), _ControlHandler)
+        self.service = service
+        self.session_path = _path(session_path)
+        self.launch_file = _path(launch_file)
+        self.log_file = _path(log_file)
+        self.token = token or secrets.token_urlsafe(32)
+        self.stop_requested = False
+        self._last_persisted_state: str | None = None
+
+    @property
+    def control_host(self) -> str:
+        return str(self.server_address[0])
+
+    @property
+    def control_port(self) -> int:
+        return int(self.server_address[1])
+
+    def session_payload(self) -> dict[str, Any]:
+        return {
+            "version": SESSION_VERSION,
+            "pid": os.getpid(),
+            "control_host": self.control_host,
+            "control_port": self.control_port,
+            "token": self.token,
+            "launch_file": str(self.launch_file),
+            "log_file": str(self.log_file),
+            "state": self.service.status(),
+        }
+
+    def persist(self, *, force: bool = False) -> None:
+        state = self.service.status()
+        if force or state != self._last_persisted_state:
+            write_session(self.session_path, self.session_payload())
+            self._last_persisted_state = state
+
+    def dispatch(self, request: Any) -> dict[str, Any]:
+        if not isinstance(request, dict):
+            return {"ok": False, "error": "request must be a JSON object", "pid": os.getpid()}
+        if request.get("token") != self.token:
+            return {"ok": False, "error": "unauthorized session token", "pid": os.getpid()}
+        expected_pid = request.get("pid")
+        if expected_pid is not None and int(expected_pid) != os.getpid():
+            return {"ok": False, "error": "session pid mismatch", "pid": os.getpid()}
+
+        command = str(request.get("command", ""))
+        if command == "status":
+            self.persist()
+            return {"ok": True, "pid": os.getpid(), "state": self.service.status()}
+        if command == "terminate":
+            self.service.terminate()
+            self.stop_requested = True
+            self.persist(force=True)
+            return {"ok": True, "pid": os.getpid(), "state": self.service.status()}
+        return {"ok": False, "error": f"unknown command: {command}", "pid": os.getpid()}
+
+    def serve_until_terminated(self, poll_interval: float = 0.2) -> None:
+        self.timeout = poll_interval
+        self.persist(force=True)
+        try:
+            while not self.stop_requested and self.service.status() != "TERMINATED":
+                self.handle_request()
+                self.persist()
+        finally:
+            self.persist(force=True)
+
+
+def send_control_command(
+    session_file: str | os.PathLike[str],
+    command: str,
+    *,
+    timeout_sec: float = 3.0,
+) -> dict[str, Any]:
+    session = read_session(session_file)
+    try:
+        host = str(session["control_host"])
+        port = int(session["control_port"])
+        token = str(session["token"])
+        pid = int(session["pid"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LauncherControlError("session file does not contain a usable control endpoint") from exc
+
+    request = {"command": command, "token": token, "pid": pid}
+    try:
+        with socket.create_connection((host, port), timeout=timeout_sec) as sock:
+            sock.settimeout(timeout_sec)
+            stream = sock.makefile("rwb")
+            stream.write((json.dumps(request) + "\n").encode("utf-8"))
+            stream.flush()
+            raw = stream.readline(_MAX_REQUEST_BYTES)
+    except OSError as exc:
+        raise LauncherControlError(f"cannot reach launcher control endpoint: {exc}") from exc
+
+    if not raw:
+        raise LauncherControlError("launcher control endpoint closed without a response")
+    try:
+        response = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise LauncherControlError("launcher control endpoint returned invalid JSON") from exc
+    if not isinstance(response, dict):
+        raise LauncherControlError("launcher control endpoint returned an invalid response")
+    if int(response.get("pid", -1)) != pid:
+        raise LauncherControlError("launcher response pid does not match session ownership")
+    if response.get("ok") is not True:
+        raise LauncherControlError(str(response.get("error", "launcher command failed")))
+    return response

--- a/src/hakoniwa_pdu/apps/launcher/hako_launcher_ctl.py
+++ b/src/hakoniwa_pdu/apps/launcher/hako_launcher_ctl.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .hako_launcher_background import (
+    LauncherControlError,
+    is_terminal_session,
+    read_session,
+    send_control_command,
+)
+
+
+def _print(payload: dict) -> None:
+    print(json.dumps(payload, ensure_ascii=False))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hakoniwa Launcher background control")
+    parser.add_argument("command", choices=["status", "terminate"])
+    parser.add_argument("session_file", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        session = read_session(args.session_file)
+    except LauncherControlError as exc:
+        print(f"[launcher-ctl] {exc}", file=sys.stderr)
+        return 2
+
+    state = str(session.get("state", "UNKNOWN"))
+    if is_terminal_session(session):
+        _print({"ok": state == "TERMINATED", "state": state, "pid": session.get("pid")})
+        return 0 if state == "TERMINATED" else 1
+
+    try:
+        response = send_control_command(args.session_file, args.command)
+    except LauncherControlError as exc:
+        _print({"ok": False, "state": "STALE", "pid": session.get("pid"), "error": str(exc)})
+        return 1
+
+    _print(response)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_launcher_background.py
+++ b/tests/test_launcher_background.py
@@ -1,0 +1,122 @@
+import json
+import threading
+
+import pytest
+
+from hakoniwa_pdu.apps.launcher.hako_launcher_background import (
+    LauncherControlError,
+    LauncherControlServer,
+    read_session,
+    send_control_command,
+    write_session,
+)
+
+
+class FakeService:
+    def __init__(self) -> None:
+        self.state = "RUNNING"
+        self.terminate_calls = 0
+
+    def status(self) -> str:
+        return self.state
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        self.state = "TERMINATED"
+
+
+def _run_server(server: LauncherControlServer) -> threading.Thread:
+    server.persist(force=True)
+    thread = threading.Thread(target=server.serve_until_terminated, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_background_control_status_and_terminate(tmp_path):
+    service = FakeService()
+    session_file = tmp_path / "launcher-session.json"
+    server = LauncherControlServer(
+        service=service,
+        session_path=session_file,
+        launch_file=tmp_path / "launch.json",
+        log_file=tmp_path / "launcher.log",
+        token="test-token",
+    )
+    thread = _run_server(server)
+    try:
+        status = send_control_command(session_file, "status")
+        assert status["ok"] is True
+        assert status["state"] == "RUNNING"
+
+        terminated = send_control_command(session_file, "terminate")
+        assert terminated["ok"] is True
+        assert terminated["state"] == "TERMINATED"
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert service.terminate_calls == 1
+        assert read_session(session_file)["state"] == "TERMINATED"
+    finally:
+        server.server_close()
+
+
+def test_mismatched_session_token_cannot_terminate(tmp_path):
+    service = FakeService()
+    real_session = tmp_path / "real.json"
+    fake_session = tmp_path / "fake.json"
+    server = LauncherControlServer(
+        service=service,
+        session_path=real_session,
+        launch_file=tmp_path / "launch.json",
+        log_file=tmp_path / "launcher.log",
+        token="real-token",
+    )
+    thread = _run_server(server)
+    try:
+        payload = read_session(real_session)
+        payload["token"] = "wrong-token"
+        write_session(fake_session, payload)
+        with pytest.raises(LauncherControlError, match="unauthorized"):
+            send_control_command(fake_session, "terminate")
+        assert service.terminate_calls == 0
+        assert service.state == "RUNNING"
+        send_control_command(real_session, "terminate")
+        thread.join(timeout=2)
+    finally:
+        server.server_close()
+
+
+def test_stale_session_never_falls_back_to_pid_kill(tmp_path):
+    session_file = tmp_path / "stale.json"
+    write_session(
+        session_file,
+        {
+            "version": 1,
+            "pid": 99999,
+            "control_host": "127.0.0.1",
+            "control_port": 1,
+            "token": "stale",
+            "launch_file": str(tmp_path / "launch.json"),
+            "state": "RUNNING",
+        },
+    )
+    with pytest.raises(LauncherControlError, match="cannot reach"):
+        send_control_command(session_file, "terminate", timeout_sec=0.1)
+
+
+def test_terminal_session_is_retained_for_post_run_status(tmp_path, capsys):
+    from hakoniwa_pdu.apps.launcher.hako_launcher_ctl import main
+
+    session_file = tmp_path / "terminated.json"
+    write_session(
+        session_file,
+        {
+            "version": 1,
+            "pid": 1234,
+            "state": "TERMINATED",
+            "launch_file": str(tmp_path / "launch.json"),
+        },
+    )
+    assert main(["status", str(session_file)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "TERMINATED"
+    assert payload["ok"] is True


### PR DESCRIPTION
## Summary

Implements the background lifecycle contract from #45.

Callers can now start a Launcher with an explicit caller-owned session file:

```bash
python -m hakoniwa_pdu.apps.launcher.hako_launcher launch.json \
  --background ./run/launcher-session.json
```

and control that same Launcher with OS-independent commands:

```bash
python -m hakoniwa_pdu.apps.launcher.hako_launcher_ctl status ./run/launcher-session.json
python -m hakoniwa_pdu.apps.launcher.hako_launcher_ctl terminate ./run/launcher-session.json
```

## Design

- The session file is the external lifecycle handle; there is no implicit global session directory.
- A background Launcher owns a localhost TCP control endpoint and random token.
- `terminate` invokes `LauncherService.terminate()` rather than killing the stored PID.
- The endpoint verifies both the token and expected PID before accepting a command.
- A stale session reports `STALE`; the control CLI never falls back to killing the recorded PID.
- The session file is written atomically and retained with `state: TERMINATED` for post-run inspection.
- Launcher stdout/stderr is written to `<session-file>.log`.
- Windows background workers are created with `CREATE_NEW_PROCESS_GROUP`; platform-specific child cleanup remains inside the existing Launcher/AssetRunner implementation.
- The Launcher module now propagates `main()` return values to the OS exit code, which is required for automation to detect background-start failures.

## Validation

Focused local tests: `4 passed`.

Covered:

- `status` / `terminate` through the control endpoint;
- mismatched session-token rejection;
- stale sessions never falling back to PID kill;
- retained terminal session status.

GitHub Actions `tests` run #158: **success** on the latest head.

Native Windows runtime verification is still desirable before treating the Windows background path as fully verified.

Closes #45
